### PR TITLE
Fix: Add outro length to prevent abrupt video cutoff

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -25,6 +25,8 @@ const jsonError = document.getElementById('json-error');
 const emptyHint = document.getElementById('empty-hint');
 const clearBtn = document.getElementById('clear-btn');
 const nameInput = document.getElementById('name-input');
+/** @type {HTMLInputElement} */
+const endPauseInput = /** @type {any} */ (document.getElementById('end-pause-input'));
 const recordBtn = document.getElementById('record-btn');
 const previewBtn = document.getElementById('preview-btn');
 const stopBtn = document.getElementById('stop-btn');
@@ -726,13 +728,18 @@ async function streamRun(fetchPromise, { onDone }) {
  * Run the current directions as a full recording (with ffmpeg video conversion)
  * via POST `/api/run`. Reloads the recordings list on successful completion.
  */
+function getEndPause() {
+  const val = parseInt(endPauseInput.value, 10);
+  return isNaN(val) || val < 0 ? 2000 : val;
+}
+
 async function runActions() {
   const name = nameInput.value.trim() || `recording-${Date.now()}`;
   await streamRun(
     fetch('/api/run', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, actions: directionsForJSON(), blueprint, videoSize: getVideoSize() }),
+      body: JSON.stringify({ name, actions: directionsForJSON(), blueprint, videoSize: getVideoSize(), endPause: getEndPause() }),
     }),
     { onDone: (msg) => { if (!msg.stopped) loadRecordings(); } }
   );
@@ -821,6 +828,7 @@ function renderSavedScripts(recordings) {
       if (!recording) return;
       directions = normalizeActions(recording.directions ?? recording.actions ?? recording.steps ?? []);
       nameInput.value = recording.name;
+      endPauseInput.value = String(recording.endPause ?? 2000);
       renderDirections();
       setStatus(statusEl, `Loaded "${name}"`);
     });
@@ -1025,7 +1033,7 @@ async function saveScript() {
     const res = await fetch('/api/scripts/save', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, directions: directionsForJSON() }),
+      body: JSON.stringify({ name, directions: directionsForJSON(), endPause: getEndPause() }),
     });
     if (!res.ok) throw new Error('Save failed');
     setStatus(statusEl, `Saved "${name}"`);
@@ -1089,7 +1097,7 @@ function exportTxt() {
 // ── Event listeners ───────────────────────────────────────────────────────────
 addBtn.addEventListener('click', addCommand);
 commandInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') addCommand(); });
-clearBtn.addEventListener('click', () => { directions = []; nameInput.value = ''; renderDirections(); });
+clearBtn.addEventListener('click', () => { directions = []; nameInput.value = ''; endPauseInput.value = '2000'; renderDirections(); });
 recordBtn.addEventListener('click', runActions);
 previewBtn.addEventListener('click', runPreview);
 stopBtn.addEventListener('click', () => fetch('/api/stop', { method: 'POST' }));

--- a/public/app.js
+++ b/public/app.js
@@ -728,10 +728,16 @@ async function streamRun(fetchPromise, { onDone }) {
  * Run the current directions as a full recording (with ffmpeg video conversion)
  * via POST `/api/run`. Reloads the recordings list on successful completion.
  */
+const endPauseDisplay = document.getElementById('end-pause-display');
+
 function getEndPause() {
-  const val = parseInt(endPauseInput.value, 10);
-  return isNaN(val) || val < 0 ? 2000 : val;
+  const secs = parseFloat(endPauseInput.value);
+  return isNaN(secs) || secs < 0 ? 2000 : Math.round(secs * 1000);
 }
+
+endPauseInput.addEventListener('input', () => {
+  endPauseDisplay.textContent = `${endPauseInput.value}s`;
+});
 
 async function runActions() {
   const name = nameInput.value.trim() || `recording-${Date.now()}`;
@@ -828,7 +834,9 @@ function renderSavedScripts(recordings) {
       if (!recording) return;
       directions = normalizeActions(recording.directions ?? recording.actions ?? recording.steps ?? []);
       nameInput.value = recording.name;
-      endPauseInput.value = String(recording.endPause ?? 2000);
+      const secs = ((recording.endPause ?? 2000) / 1000).toString();
+      endPauseInput.value = secs;
+      endPauseDisplay.textContent = `${secs}s`;
       renderDirections();
       setStatus(statusEl, `Loaded "${name}"`);
     });
@@ -1097,7 +1105,7 @@ function exportTxt() {
 // ── Event listeners ───────────────────────────────────────────────────────────
 addBtn.addEventListener('click', addCommand);
 commandInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') addCommand(); });
-clearBtn.addEventListener('click', () => { directions = []; nameInput.value = ''; endPauseInput.value = '2000'; renderDirections(); });
+clearBtn.addEventListener('click', () => { directions = []; nameInput.value = ''; endPauseInput.value = '2'; endPauseDisplay.textContent = '2s'; renderDirections(); });
 recordBtn.addEventListener('click', runActions);
 previewBtn.addEventListener('click', runPreview);
 stopBtn.addEventListener('click', () => fetch('/api/stop', { method: 'POST' }));

--- a/public/index.html
+++ b/public/index.html
@@ -29,11 +29,6 @@
       Name:
       <input id="name-input" type="text" placeholder="Add script name">
     </label>
-    <label>
-      Pause at end:
-      <input id="end-pause-input" type="range" min="0" max="10" step="0.5" value="2">
-      <span id="end-pause-display">2s</span>
-    </label>
     <button id="save-btn" class="secondary" disabled>Save Script</button>
     <button id="export-txt-btn" class="secondary" disabled>Export TXT</button>
     <button id="clear-btn" class="secondary">Clear</button>
@@ -45,6 +40,11 @@
       <button type="button" class="size-opt active" data-size="1920x1080" role="radio" aria-checked="true" title="1080p (1920×1080)">1080p</button>
       <button type="button" class="size-opt" data-size="3840x2160" role="radio" aria-checked="false" title="4K (3840×2160)">4K</button>
     </div>
+    <label>
+      Outro length:
+      <input id="end-pause-input" type="range" min="0" max="10" step="0.5" value="2">
+      <span id="end-pause-display">2s</span>
+    </label>
   </div>
 
   <div class="workspace">

--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,10 @@
       Name:
       <input id="name-input" type="text" placeholder="Add script name">
     </label>
+    <label>
+      End pause (ms):
+      <input id="end-pause-input" type="number" min="0" step="500" value="2000">
+    </label>
     <button id="save-btn" class="secondary" disabled>Save Script</button>
     <button id="export-txt-btn" class="secondary" disabled>Export TXT</button>
     <button id="clear-btn" class="secondary">Clear</button>

--- a/public/index.html
+++ b/public/index.html
@@ -30,8 +30,9 @@
       <input id="name-input" type="text" placeholder="Add script name">
     </label>
     <label>
-      End pause (ms):
-      <input id="end-pause-input" type="number" min="0" step="500" value="2000">
+      Pause at end:
+      <input id="end-pause-input" type="range" min="0" max="10" step="0.5" value="2">
+      <span id="end-pause-display">2s</span>
     </label>
     <button id="save-btn" class="secondary" disabled>Save Script</button>
     <button id="export-txt-btn" class="secondary" disabled>Export TXT</button>

--- a/public/style.css
+++ b/public/style.css
@@ -435,6 +435,39 @@ header p {
 
 .direction-bar label input:focus { border-color: #6366f1; }
 
+.direction-bar label input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  background: #2d3748;
+  border: none;
+  border-radius: 4px;
+  height: 4px;
+  padding: 0;
+  width: 100px;
+}
+.direction-bar label input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  background: #6366f1;
+  border-radius: 50%;
+  cursor: pointer;
+  height: 14px;
+  width: 14px;
+}
+.direction-bar label input[type="range"]::-moz-range-thumb {
+  background: #6366f1;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  height: 14px;
+  width: 14px;
+}
+#end-pause-display {
+  color: #f1f5f9;
+  font-size: 0.85rem;
+  min-width: 2.5rem;
+}
+
 .size-toggle {
   display: inline-flex;
   background: #1a2035;

--- a/recordings/actions-runner.spec.js
+++ b/recordings/actions-runner.spec.js
@@ -22,6 +22,7 @@ const fs = require('fs');
 const path = require('path');
 
 const HIGHLIGHT_HOLD = 1000;
+const DEFAULT_END_PAUSE = 2000;
 
 /**
  * Scroll `locator` into view, inject a pulsing blue ring around it for
@@ -365,5 +366,7 @@ for (const file of stepFiles) {
         }
       });
     }
+
+    await page.waitForTimeout(def.endPause ?? DEFAULT_END_PAUSE);
   });
 }

--- a/src/routes/runner.js
+++ b/src/routes/runner.js
@@ -143,13 +143,15 @@ function register(app) {
   // Single-recording run: write the posted steps to a file, then grep for
   // exactly this recording by its `name`.
   app.post('/api/run', async (req, res) => {
-    const { name = `recording-${Date.now()}`, actions = [], blueprint = null, videoSize = null, preview = false } = req.body;
+    const { name = `recording-${Date.now()}`, actions = [], blueprint = null, videoSize = null, preview = false, endPause } = req.body;
     if (!actions.length) return res.status(400).json({ error: 'no actions provided' });
 
     if (!fs.existsSync(STEPS_DIR)) fs.mkdirSync(STEPS_DIR);
     const filename = nameToFilename(name);
     const filePath = path.join(STEPS_DIR, filename);
-    fs.writeFileSync(filePath, JSON.stringify({ name, actions }, null, 2));
+    const scriptData = { name, actions };
+    if (endPause != null) scriptData.endPause = endPause;
+    fs.writeFileSync(filePath, JSON.stringify(scriptData, null, 2));
 
     sseHeaders(res);
     const send = sseSender(res);

--- a/src/routes/scripts.js
+++ b/src/routes/scripts.js
@@ -51,6 +51,7 @@ function register(app) {
           filename: f,
           directionCount: directions.length,
           directions,
+          endPause: def.endPause,
         };
       } catch {
         // Skip malformed files rather than failing the whole listing.
@@ -61,10 +62,12 @@ function register(app) {
   });
 
   app.post('/api/scripts/save', (req, res) => {
-    const { name = `recording-${Date.now()}`, directions = [] } = req.body;
+    const { name = `recording-${Date.now()}`, directions = [], endPause } = req.body;
     if (!fs.existsSync(STEPS_DIR)) fs.mkdirSync(STEPS_DIR);
     const filename = nameToFilename(name);
-    fs.writeFileSync(path.join(STEPS_DIR, filename), JSON.stringify({ name, directions }, null, 2));
+    const scriptData = { name, directions };
+    if (endPause != null) scriptData.endPause = endPause;
+    fs.writeFileSync(path.join(STEPS_DIR, filename), JSON.stringify(scriptData, null, 2));
     res.json({ filename });
   });
 


### PR DESCRIPTION
## Summary

Closes #1

- Adds a 2-second default hold after the last step in every recording, so the final frame lingers instead of cutting off abruptly
- Introduces an optional `endPause` field (in ms) on the step definition JSON to override the default per script
- Exposes this as an **Outro length** slider (0–10 s, 0.5 s steps) in the UI, positioned to the right of the video resolution selector
- The value round-trips correctly through run, save, load, and clear

## Test plan

- [x] Run any script and confirm the output video holds on the final frame for ~2 seconds before ending
- [x] Drag the Outro length slider to 5s, re-run, confirm the video holds for ~5 seconds
- [x] Save a script with a custom outro length, reload the page, load the script — confirm the slider restores to the saved value
- [x] Inspect the saved `.json` file and confirm `endPause` is present at the top level
- [x] Clear the script and confirm the slider resets to 2s

🤖 Generated with [Claude Code](https://claude.com/claude-code)