### PR TITLE
Fix translating status disappearing before steps render

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -511,11 +511,11 @@ function renderBlueprint() {
  * @param {string} msg
  * @param {boolean} [isError]
  */
-function setStatus(el, msg, isError = false) {
+function setStatus(el, msg, isError = false, persist = false) {
   el.textContent = msg;
   el.className = 'status' + (isError ? ' error' : '');
   el.classList.remove('hidden');
-  if (!isError) setTimeout(() => el.classList.add('hidden'), 3000);
+  if (!isError && !persist) setTimeout(() => el.classList.add('hidden'), 3000);
 }
 
 // ── JSON edit handlers ────────────────────────────────────────────────────────
@@ -583,7 +583,7 @@ async function addCommand() {
 
   addBtn.disabled = true;
   commandInput.disabled = true;
-  setStatus(statusEl, 'Translating…');
+  setStatus(statusEl, 'Translating…', false, true);
 
   try {
     const flatHistory = directions.flatMap(g => g.actions ?? []);


### PR DESCRIPTION
## Summary

- The "Translating…" status message was auto-hiding after 3 seconds (same as success messages), leaving the UI looking idle while the API was still processing
- Added a `persist` parameter to `setStatus()` to suppress the auto-hide timer
- The "Translating…" call now passes `persist: true`, keeping the message visible until the success message replaces it after `renderDirections()` completes

Closes #11

## Test plan

- [ ] Type a command that takes longer than 3 seconds to translate i.e Create a new page pre-populated with a title, 3 paragraphs and 3 heading all with random text.
- [ ] Verify "Translating…" stays visible the entire time until steps appear
- [ ] Verify the success message ("Added N direction(s)") still auto-hides after 3 seconds as normal
- [ ] Verify error messages still persist as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)