### PR TITLE
Switch wpSetPostTitle and wpSetBlockContent to slow-type by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,8 +97,8 @@ Step definitions live in `steps/*.json`. Each file is one recording:
 | `wpInsertBlockProgrammatic` | `blockType`, `attributes?` | Inserts via `wp.blocks.createBlock` + `wp.data.dispatch`. Invisible but reliable; use for setup steps that don't need to appear on screen. Short names auto-prefixed with `core/`. |
 | `wpDeleteBlock` | `blockType`, `index?` | Selects block, presses Escape to enter block-selection mode, then Backspace to remove |
 | `wpCommandPalette` | `command?` | Opens with `Meta+K`; if `command` is given, types it and presses Enter |
-| `wpSetPostTitle` | `title` | Waits for and fills the post/page title inside the editor iframe — handles frame context internally |
-| `wpSetPostContent` | `content`, `blockType?`, `index?`, `delay?` | Sets content in a block using `fill()`. When `blockType`/`index` are given, targets that block directly (0-based index); otherwise targets the last non-title block. Always replaces existing content. |
+| `wpSetPostTitle` | `title`, `programmatic?`, `delay?` | Slow-types the post/page title inside the editor iframe by default; set `programmatic: true` for instant silent fill. |
+| `wpSetBlockContent` | `content`, `blockType?`, `index?`, `replace?`, `delay?` | Slow-types text into a block. Triple-clicks to replace existing content first (`replace` defaults to `true`); set `replace: false` to append. Targets block by `blockType`/`index` or the last non-title block if omitted. |
 | `wpSiteEditorSave` | — | Clicks Save in the site editor top bar then confirms in the publish panel. |
 | `wpOpenBlockInserter` | — | Toggles the Block Inserter panel open. |
 | `wpInsertBlockFromPanel` | `blockType` | Opens the block inserter, searches by block name, and clicks the matching result. |

--- a/public/app.js
+++ b/public/app.js
@@ -248,7 +248,7 @@ function describePlain(step) {
     case 'wpDeleteBlock':   return `Delete the ${step.blockType} block`;
     case 'wpCommandPalette':return step.command != null ? `Run command "${step.command}"` : 'Open the command palette';
     case 'wpSetPostTitle':  return `Set the post title to "${step.title}"`;
-    case 'wpSetPostContent':return `Set ${step.blockType ? step.blockType + ' block' : 'block'} content to "${step.content}"`;
+    case 'wpSetBlockContent':return `Set ${step.blockType ? step.blockType + ' block' : 'block'} content to "${step.content}"`;
     default:                return step.action;
   }
 }

--- a/recordings/run-steps.js
+++ b/recordings/run-steps.js
@@ -178,14 +178,18 @@ async function runStep(step, page, frameStack, ctx, sidebar) {
 
     case 'wpSetPostTitle': {
       const editorFrame = page.frameLocator('iframe[name="editor-canvas"]');
-      await editorFrame.locator('.wp-block-post-title').waitFor({ state: 'visible', timeout: 30_000 });
-      await editorFrame.locator('.wp-block-post-title').click();
-      await editorFrame.locator('.wp-block-post-title').fill(step.title);
+      const titleLocator = editorFrame.locator('.wp-block-post-title');
+      await titleLocator.waitFor({ state: 'visible', timeout: 30_000 });
+      if (step.programmatic) {
+        await titleLocator.fill(step.title);
+      } else {
+        await typeSlow(titleLocator, step.title, step.delay ?? 100);
+      }
       await page.waitForTimeout(300);
       break;
     }
 
-    case 'wpSetPostContent': {
+    case 'wpSetBlockContent': {
       const editorFrame = page.frameLocator('iframe[name="editor-canvas"]');
       await editorFrame.locator('.wp-block-post-title').waitFor({ state: 'visible', timeout: 30_000 });
       let targetLocator;
@@ -198,7 +202,11 @@ async function runStep(step, page, frameStack, ctx, sidebar) {
         targetLocator = editorFrame.locator('[contenteditable="true"]:not(.wp-block-post-title)').last();
       }
       await targetLocator.waitFor({ state: 'visible', timeout: 10_000 });
-      await targetLocator.fill(step.content);
+      const replace = step.replace !== false;
+      const delay = step.delay ?? 100;
+      await targetLocator.scrollIntoViewIfNeeded();
+      await targetLocator.click({ clickCount: replace ? 3 : 1 });
+      await targetLocator.pressSequentially(step.content, { delay });
       await page.waitForTimeout(300);
       break;
     }

--- a/src/claude.js
+++ b/src/claude.js
@@ -150,8 +150,8 @@ After navigating to new-post or new-page, always emit \`tryClick\` with selector
 - wpInsertBlock: { "action": "wpInsertBlock", "blockType": "paragraph"|"heading"|"image"|etc, "afterIndex"?: number } — use when user says "type", "insert", "add", "write", or implies a visible on-screen action; types the slash command so it appears in the recording
 - wpInsertBlockProgrammatic: { "action": "wpInsertBlockProgrammatic", "blockType": "string", "attributes"?: object } — use when user says "programmatically", "silently", "in the background", "set up", or "pre-populate"; inserts via JS API with no visible UI interaction
 - wpDeleteBlock: { "action": "wpDeleteBlock", "blockType": "paragraph"|"heading"|"image"|etc, "index"?: number }
-- wpSetPostTitle: { "action": "wpSetPostTitle", "title": "string" }
-- wpSetPostContent: { "action": "wpSetPostContent", "content": "string", "blockType"?: "heading"|"paragraph"|etc, "index"?: number, "replace"?: boolean, "delay"?: number } — types into a block; when blockType is given, targets that specific block by index (0-based); replace defaults to true (triple-click to select all existing text first); set replace:false to append
+- wpSetPostTitle: { "action": "wpSetPostTitle", "title": "string", "programmatic"?: boolean, "delay"?: number } — default slow-types the title; add programmatic:true to set it instantly with no visible typing
+- wpSetBlockContent: { "action": "wpSetBlockContent", "content": "string", "blockType"?: "heading"|"paragraph"|etc, "index"?: number, "replace"?: boolean, "delay"?: number } — types into a block; when blockType is given, targets that specific block by index (0-based); replace defaults to true (triple-click to select all existing text first); set replace:false to append
 - wpSiteEditorSave: { "action": "wpSiteEditorSave" } — clicks Save in the site editor top bar, then confirms in the publish panel
 - wpInsertBlockFromPanel: { "action": "wpInsertBlockFromPanel", "blockType": "string" } — opens the inserter, searches by name, and clicks the matching block option
 - wpInspectorPanel: { "action": "wpInspectorPanel", "panel": "string" } — opens a collapsible panel in the inspector sidebar by name (e.g. "Categories", "Tags", "Featured image", "Permalink", "Excerpt", "Status and Visibility"); opens the sidebar automatically if needed
@@ -167,9 +167,9 @@ After navigating to new-post or new-page, always emit \`tryClick\` with selector
 - Include waitForSelector before interacting with elements that may not be immediately present
 - When entering the block editor, frameLocator to 'iframe[name="editor-canvas"]' MUST come first — before any waitForSelector, click, fill, or type that targets editor content. exitFrame after.
 - To insert a block, choose based on user intent: use wpInsertBlock (slash-command UI) when the user says "type", "insert", "add", "write", or implies a visible on-screen action; use wpInsertBlockProgrammatic when the user says "programmatically", "silently", "in the background", "set up", or "pre-populate" — invisible, no UI interaction shown in the recording
-- To set the post/page title, always use wpSetPostTitle — never manually frameLocator + click/fill the title field
-- To update/replace content of a specific block, use wpSetPostContent with blockType and index — do NOT use wpSelectBlock followed by wpSetPostContent
-- To set/replace/update block content, use wpSetPostContent — it triple-clicks to select all existing text first (replace:true by default); only pass replace:false when the intent is to append
+- To set the post/page title, always use wpSetPostTitle — never manually frameLocator + click/fill the title field; default to slow-type (visible); add programmatic:true when the user says "programmatically", "silently", "in the background", "set up", or "pre-populate"
+- To update/replace content of a specific block, use wpSetBlockContent with blockType and index — do NOT use wpSelectBlock followed by wpSetBlockContent
+- To set/replace/update block content, use wpSetBlockContent — it triple-clicks to select all existing text first (replace:true by default); only pass replace:false when the intent is to append
 - To save changes in the site editor, use wpSiteEditorSave — do NOT use generic click on the Save button
 - To click admin sidebar items by label, use highlightClick with selector #adminmenu a:has-text("<Label>"); follow with waitForSelector on a landmark element of the destination page
 - To interact with block formatting toolbar (Bold, Italic, alignment, etc.), use highlightClick with selector [role="toolbar"][aria-label="Block tools"] button[aria-label="<ButtonName>"]


### PR DESCRIPTION
## Summary

- `wpSetPostTitle` now slow-types the title character-by-character via `typeSlow` by default; add `programmatic: true` to get the old instant `fill()` behaviour for silent setup steps (same pattern as `wpInsertBlockProgrammatic`)
- `wpSetBlockContent` (renamed from `wpSetPostContent`) replaces `fill()` with triple-click + `pressSequentially` for replace mode and single-click + `pressSequentially` for append mode, so content visibly types out in recordings
- Updated `src/claude.js` system prompt with the new action name, `programmatic` flag, and NL trigger keywords
- Updated `CLAUDE.md` to reflect the new params and actual behaviour

Related #17