### PR TITLE
Add defaults and highlight clicks to plugin/theme installers

### DIFF
--- a/recordings/run-steps.js
+++ b/recordings/run-steps.js
@@ -158,18 +158,19 @@ async function runStep(step, page, frameStack, ctx, sidebar) {
 
     case 'wpInstallPlugin': {
       await page.goto('/wp-admin/plugin-install.php', { waitUntil: 'domcontentloaded' });
-      await page.waitForTimeout(500);
-      await page.locator('#search-plugins').fill(step.slug);
-      await page.keyboard.press('Enter');
+      const pluginSearchInput = page.locator('#search-plugins');
+      await pluginSearchInput.waitFor({ state: 'visible' });
+      await typeSlow(pluginSearchInput, step.slug);
       await page.waitForLoadState('networkidle');
       await page.waitForTimeout(800);
       const installBtn = page.locator(`.plugin-card-${step.slug} .install-now`);
       await installBtn.waitFor({ timeout: 15_000 });
-      await installBtn.click();
-      await page.locator(`.plugin-card-${step.slug} .activate-now`).waitFor({ timeout: 30_000 });
+      await highlightAndClick(page, installBtn);
+      const activateBtn = page.locator(`.plugin-card-${step.slug} .activate-now`);
+      await activateBtn.waitFor({ timeout: 30_000 });
       await page.waitForTimeout(600);
       if (step.activate) {
-        await page.locator(`.plugin-card-${step.slug} .activate-now`).click();
+        await highlightAndClick(page, activateBtn);
         await page.waitForLoadState('networkidle');
         await page.waitForTimeout(800);
       }

--- a/src/claude.js
+++ b/src/claude.js
@@ -182,8 +182,8 @@ After navigating to new-post or new-page, always emit \`tryClick\` with selector
 - ALWAYS use slowType instead of fill or type for any text the user is entering — never use fill for visible input fields; fill is only for hidden or off-screen fields
 - After navigation, prefer waitForSelector targeting the first element you will interact with — do NOT use wait steps as a blanket post-navigation pause
 - Only use wait (ms) for deliberate visual pauses in a recording (e.g. holding a result on screen); do not use it to paper over load timing
-- Use wpInstallPlugin for installing plugins — derive the slug from the plugin name (lowercase, hyphens)
-- Use wpInstallTheme for installing themes — derive the slug from the theme name (lowercase, hyphens); pass name only when the display name differs from the title-cased slug
+- Use wpInstallPlugin for installing plugins — derive the slug from the plugin name (lowercase, hyphens); if no plugin is specified, default to slug "gutenberg" (Gutenberg)
+- Use wpInstallTheme for installing themes — derive the slug from the theme name (lowercase, hyphens); pass name only when the display name differs from the title-cased slug; if no theme is specified, default to slug "blockbase" (Blockbase)
 - For WordPress admin navigation, use navigate with the URL path from the WordPress Admin URLs table; always set waitUntil: "domcontentloaded"
 - After navigating to new-post or new-page, emit tryClick with selector .components-modal__header button[aria-label="Close"] to dismiss the welcome dialog
 - Include waitForSelector before interacting with elements that may not be immediately present


### PR DESCRIPTION
## Summary

- `wpInstallPlugin` now uses `typeSlow` for the search field and `highlightAndClick` for the Install and Activate buttons, matching the visual treatment already used by `wpInstallTheme`
- NL translation now defaults to the Gutenberg plugin when no plugin is specified, and the Blockbase theme when no theme is specified

## Test plan

- [ ] Run a recording that installs a plugin — confirm the search types character-by-character and the Install/Activate buttons pulse before clicking
- [ ] Translate a NL command like "install a theme" with no theme name — confirm Blockbase is chosen
- [ ] Translate a NL command like "install a plugin" with no plugin name — confirm Gutenberg is chosen