### PR TITLE
Explicitly disable all debug constants in default blueprint

### DIFF
--- a/blueprints/blueprint.json
+++ b/blueprints/blueprint.json
@@ -8,6 +8,16 @@
   },
   "steps": [
     {
+      "step": "defineWpConfigConsts",
+      "consts": {
+        "WP_DEBUG": false,
+        "WP_DEBUG_LOG": false,
+        "WP_DEBUG_DISPLAY": false,
+        "SCRIPT_DEBUG": false,
+        "SAVEQUERIES": false
+      }
+    },
+    {
       "step": "login",
       "username": "admin",
       "password": "password"


### PR DESCRIPTION
## Summary

- Adds a `defineWpConfigConsts` step to `blueprints/blueprint.json`
- Sets `WP_DEBUG`, `WP_DEBUG_LOG`, `WP_DEBUG_DISPLAY`, `SCRIPT_DEBUG`, and `SAVEQUERIES` to `false`
- Prevents any debug output or query logging from appearing in recordings

## Test plan

- [ ] Add the direction "Install Jetpack"
- [ ] Preview or record the video to confirm that the deprecated error doesn't appear.
- [ ] Remove the `defineWpConfigConsts` from the default blueprint.
- [ ] Run the same video and confirm that the error is shown.

## Result
[video.webm](https://github.com/user-attachments/assets/4da03c9d-34f3-47c3-ac4b-28afa19e321d)