### PR TITLE
Fix admin menu selectors and navigation edge cases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ Step definitions live in `steps/*.json`. Each file is one recording:
 | `wpSiteEditorSave` | — | Clicks Save in the site editor top bar then confirms in the publish panel. |
 | `wpOpenBlockInserter` | — | Toggles the Block Inserter panel open. |
 | `wpInsertBlockFromPanel` | `blockType` | Opens the block inserter, searches by block name, and clicks the matching result. |
-| `wpAdminMenuClick` | `item` | Clicks an admin sidebar link whose text matches `item` (e.g. `"Appearance"`, `"Plugins"`). |
+| `wpAdminMenuClick` | `item` | Clicks an admin sidebar menu item by exact label (e.g. `"Posts"`, `"Appearance"`, `"Settings"`). Uses `getByRole('link', { name: item, exact: true })` scoped to `#adminmenu` — works for built-in and custom plugin/theme items. |
 | `wpBlockToolbar` | `button` | Clicks a button in the block tools toolbar by accessible name (e.g. `"Bold"`, `"Italic"`, `"Align text"`). |
 | `wpToggleInspector` | — | Toggles the Settings/Inspector sidebar open or closed. |
 | `wpInspectorTab` | `tab` | Switches the inspector sidebar tab: `"Post"`, `"Block"`, or `"Styles"`. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,9 @@ Step definitions live in `steps/*.json`. Each file is one recording:
 | `wpSiteEditorSave` | — | Clicks Save in the site editor top bar then confirms in the publish panel. |
 | `wpOpenBlockInserter` | — | Toggles the Block Inserter panel open. |
 | `wpInsertBlockFromPanel` | `blockType` | Opens the block inserter, searches by block name, and clicks the matching result. |
-| `wpAdminMenuClick` | `item` | Clicks an admin sidebar menu item by exact label (e.g. `"Posts"`, `"Appearance"`, `"Settings"`). Uses `getByRole('link', { name: item, exact: true })` scoped to `#adminmenu` — works for built-in and custom plugin/theme items. |
+| `wpEditorWPMenuClick` | — | Clicks the WordPress logo button at the top-left of the block editor header. |
+| `wpEditorToggleFullscreen` | `enable?` | Opens Editor Options → Preferences and sets the Fullscreen mode toggle. Pass `enable: false` to turn fullscreen off, revealing the WP admin sidebar. Default: `true`. |
+| `wpAdminMenuClick` | `item` | Clicks an admin sidebar menu item by exact label (e.g. `"Posts"`, `"Appearance"`, `"Settings"`, `"Updates"`). Checks top-level items first, then submenu items — works for built-in, submenu (e.g. Dashboard → Updates), and custom plugin/theme items. |
 | `wpBlockToolbar` | `button` | Clicks a button in the block tools toolbar by accessible name (e.g. `"Bold"`, `"Italic"`, `"Align text"`). |
 | `wpToggleInspector` | — | Toggles the Settings/Inspector sidebar open or closed. |
 | `wpInspectorTab` | `tab` | Switches the inspector sidebar tab: `"Post"`, `"Block"`, or `"Styles"`. |

--- a/blueprints/blueprint.json
+++ b/blueprints/blueprint.json
@@ -21,6 +21,10 @@
       "step": "login",
       "username": "admin",
       "password": "password"
+    },
+    {
+      "step": "runPHP",
+      "code": "<?php require_once '/wordpress/wp-load.php'; $user = get_user_by('login', 'admin'); $prefs = [ '_modified' => date('c'), 'core/edit-post' => [ 'welcomeGuide' => false, 'fullscreenMode' => false ], 'core/edit-site' => [ 'welcomeGuide' => false ] ]; update_user_meta($user->ID, 'wp_persisted_preferences', $prefs); update_user_option($uid, 'acknowledged_edit_file_warning', true); ?>"
     }
   ]
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -7,7 +7,7 @@ module.exports = defineConfig({
   testDir: './recordings',
   outputDir: './output',
   workers: 1,
-  timeout: 120_000,
+  timeout: 300_000,
 
   globalSetup: './global-setup.js',
   globalTeardown: './global-teardown.js',

--- a/recordings/run-steps.js
+++ b/recordings/run-steps.js
@@ -363,6 +363,18 @@ async function runStep(step, page, frameStack, ctx, sidebar) {
       break;
     }
 
+    case 'wpAdminMenuClick': {
+      // Target .wp-menu-name span to match only the label text, ignoring update
+      // count badges (e.g. "Plugins 2") that would break an exact accessible-name match.
+      const menuLink = page
+        .locator('#adminmenu > li')
+        .filter({ has: page.locator(`.wp-menu-name:text-is("${step.item}")`) })
+        .locator('> a')
+        .first();
+      await highlightAndClick(page, menuLink);
+      break;
+    }
+
     case 'wpOpenOptionsMenu': {
       const btn = ctx().locator(step.selector);
       const expanded = await btn.getAttribute('aria-expanded');

--- a/recordings/run-steps.js
+++ b/recordings/run-steps.js
@@ -150,8 +150,11 @@ async function runStep(step, page, frameStack, ctx, sidebar) {
 
     case 'tryClick': {
       try {
-        await ctx().locator(step.selector).waitFor({ state: 'visible', timeout: step.timeout ?? 3_000 });
-        await ctx().locator(step.selector).click();
+        const loc = step.role
+          ? ctx().getByRole(step.role, { name: step.name, exact: step.exact ?? true })
+          : ctx().locator(step.selector);
+        await loc.waitFor({ state: 'visible', timeout: step.timeout ?? 3_000 });
+        await loc.click();
       } catch { /* element not present, continue */ }
       break;
     }
@@ -364,14 +367,50 @@ async function runStep(step, page, frameStack, ctx, sidebar) {
     }
 
     case 'wpAdminMenuClick': {
-      // Target .wp-menu-name span to match only the label text, ignoring update
-      // count badges (e.g. "Plugins 2") that would break an exact accessible-name match.
-      const menuLink = page
+      // Try top-level items first (.wp-menu-name ignores update count badges).
+      // Fall back to submenu items (e.g. "Updates" under "Dashboard").
+      const topLevel = page
         .locator('#adminmenu > li')
         .filter({ has: page.locator(`.wp-menu-name:text-is("${step.item}")`) })
         .locator('> a')
         .first();
+      const subLevel = page.locator(
+        `#adminmenu .wp-submenu li a:text-is("${step.item}")`
+      ).first();
+      const topCount = await topLevel.count();
+      const menuLink = topCount > 0 ? topLevel : subLevel;
       await highlightAndClick(page, menuLink);
+      await page.waitForLoadState('domcontentloaded');
+      break;
+    }
+
+    case 'wpEditorWPMenuClick': {
+      // Click the WordPress logo button at the top-left of the block editor.
+      await highlightAndClick(page, page.getByRole('button', { name: 'WordPress', exact: true }));
+      await page.waitForTimeout(300);
+      break;
+    }
+
+    case 'wpEditorToggleFullscreen': {
+      // Open Editor Options → Preferences and set the Fullscreen mode checkbox.
+      // Pass `enable: false` to turn fullscreen off (reveals the WP admin sidebar).
+      const optionsBtn = page.getByRole('button', { name: 'Options', exact: true });
+      await highlightAndClick(page, optionsBtn);
+      await page.waitForTimeout(300);
+      const prefsItem = page.getByRole('menuitem', { name: 'Preferences' });
+      await prefsItem.waitFor({ state: 'visible', timeout: 5_000 });
+      await prefsItem.click();
+      const modal = page.getByRole('dialog', { name: 'Preferences' });
+      await modal.waitFor({ state: 'visible', timeout: 5_000 });
+      const toggle = modal.getByRole('checkbox', { name: 'Fullscreen mode' });
+      await toggle.waitFor({ timeout: 3_000 });
+      const shouldEnable = step.enable !== false;
+      if (shouldEnable !== await toggle.isChecked()) {
+        await toggle.click();
+        await page.waitForTimeout(300);
+      }
+      await modal.getByRole('button', { name: 'Close' }).click();
+      await page.waitForTimeout(300);
       break;
     }
 
@@ -389,10 +428,14 @@ async function runStep(step, page, frameStack, ctx, sidebar) {
       throw new Error(`Unknown action: "${step.action}"`);
   }
 
-  // If the sidebar was open before this action and has since closed, reopen it.
+  // If the sidebar was open before this action and has since closed, reopen it —
+  // but only if the Settings button is still on the page (i.e. we're still in the editor).
   if (sidebarWasOpen && !(await sidebar.isVisible())) {
-    await page.getByRole('button', { name: 'Settings', exact: true }).click();
-    await sidebar.waitFor({ state: 'visible', timeout: 5_000 });
+    const settingsBtn = page.getByRole('button', { name: 'Settings', exact: true });
+    if (await settingsBtn.isVisible()) {
+      await settingsBtn.click();
+      await sidebar.waitFor({ state: 'visible', timeout: 5_000 });
+    }
   }
 }
 

--- a/src/claude.js
+++ b/src/claude.js
@@ -86,9 +86,11 @@ After navigating to new-post or new-page, always emit \`tryClick\` with selector
 
 ### WordPress Common Selectors
 
-**Admin sidebar navigation** — to click a menu item by label:
-  Use \`highlightClick\` with selector \`#adminmenu a:has-text("<Label>")\`
-  After clicking (which triggers navigation), emit \`waitForSelector\` on a landmark element of the destination page.
+**Admin sidebar navigation** — navigating to any WordPress admin screen reachable via the sidebar:
+  ALWAYS use \`wpAdminMenuClick\` with \`item\` set to the exact menu label (e.g. \`"Posts"\`, \`"Appearance"\`, \`"Settings"\`, \`"Plugins"\`, \`"Users"\`, \`"Tools"\`, \`"Dashboard"\`, \`"Media"\`, \`"Pages"\`, \`"Comments"\`).
+  This applies whether the user says "go to", "navigate to", "open", "click", or any other phrasing — if the destination is in the admin sidebar, use \`wpAdminMenuClick\`.
+  Do NOT use \`navigate\` for admin pages that are reachable via the sidebar. \`navigate\` is only for pages not in the sidebar (e.g. post editor, a specific settings subpage).
+  After \`wpAdminMenuClick\`, always emit \`waitForSelector\` on a landmark element of the destination page (e.g. \`#wpbody\`).
 
 **Block toolbar buttons** (Bold, Italic, Link, Align text, etc.):
   Use \`highlightClick\` with selector \`[role="toolbar"][aria-label="Block tools"] button[aria-label="<ButtonName>"]\`
@@ -165,6 +167,7 @@ After navigating to new-post or new-page, always emit \`tryClick\` with selector
 ### WordPress-specific (prefer these when intent is WordPress-related)
 - tryClick: { "action": "tryClick", "selector": "string", "timeout"?: number } — clicks an element only if it appears within timeout; silently skips if absent. Use for optional UI like welcome dialogs.
 - wpOpenOptionsMenu: { "action": "wpOpenOptionsMenu", "selector": "button[aria-label=\"<Panel> options\"]" } — opens a sidebar panel's options (⋮) menu; skips the click if the menu is already open. ALWAYS use this instead of highlightClick when opening an options menu.
+- wpAdminMenuClick: { "action": "wpAdminMenuClick", "item": "string" } — clicks an admin sidebar menu item by exact label; works for built-in and plugin/theme custom items
 - wpInstallPlugin: { "action": "wpInstallPlugin", "slug": "plugin-slug", "activate"?: boolean }
 - wpInstallTheme: { "action": "wpInstallTheme", "slug": "theme-slug", "name"?: "Display Name", "activate"?: boolean }
 - wpSelectBlock: { "action": "wpSelectBlock", "blockType": "paragraph"|"heading"|"image"|etc, "index"?: number }
@@ -193,7 +196,7 @@ After navigating to new-post or new-page, always emit \`tryClick\` with selector
 - To update/replace content of a specific block, use wpSetBlockContent with blockType and index — do NOT use wpSelectBlock followed by wpSetBlockContent
 - To set/replace/update block content, use wpSetBlockContent — it triple-clicks to select all existing text first (replace:true by default); only pass replace:false when the intent is to append
 - To save changes in the site editor, use wpSiteEditorSave — do NOT use generic click on the Save button
-- To click admin sidebar items by label, use highlightClick with selector #adminmenu a:has-text("<Label>"); follow with waitForSelector on a landmark element of the destination page
+- For ANY navigation to an admin page reachable via the sidebar (Posts, Pages, Media, Comments, Appearance, Plugins, Users, Tools, Settings, Dashboard, or custom plugin/theme items), ALWAYS use wpAdminMenuClick — never use navigate for these; navigate is only for pages not in the sidebar such as the post editor or specific settings subpages
 - To interact with block formatting toolbar (Bold, Italic, alignment, etc.), use highlightClick with selector [role="toolbar"][aria-label="Block tools"] button[aria-label="<ButtonName>"]
 - To open sidebar panels like Categories or Tags, use wpInspectorPanel — it opens the sidebar automatically if needed
 - Collapsed meta boxes in the classic editor render with .postbox.closed by default — click the .postbox-header button to expand, then waitForSelector on the revealed content before interacting

--- a/src/claude.js
+++ b/src/claude.js
@@ -82,15 +82,34 @@ Always use \`"waitUntil": "domcontentloaded"\` for WordPress admin navigation.
 | Users | /wp-admin/users.php |
 | Profile | /wp-admin/profile.php |
 
-After navigating to new-post or new-page, always emit \`tryClick\` with selector \`.components-modal__header button[aria-label="Close"]\` to dismiss the welcome dialog if it appears.
+After navigating to new-post or new-page, always emit \`tryClick\` with \`role: "button"\`, \`name: "Close"\`, and \`timeout: 5000\` to dismiss the welcome dialog if it appears.
 
 ### WordPress Common Selectors
 
 **Admin sidebar navigation** — navigating to any WordPress admin screen reachable via the sidebar:
-  ALWAYS use \`wpAdminMenuClick\` with \`item\` set to the exact menu label (e.g. \`"Posts"\`, \`"Appearance"\`, \`"Settings"\`, \`"Plugins"\`, \`"Users"\`, \`"Tools"\`, \`"Dashboard"\`, \`"Media"\`, \`"Pages"\`, \`"Comments"\`).
+  ALWAYS use \`wpAdminMenuClick\` with \`item\` set to the exact menu label from the table below.
   This applies whether the user says "go to", "navigate to", "open", "click", or any other phrasing — if the destination is in the admin sidebar, use \`wpAdminMenuClick\`.
   Do NOT use \`navigate\` for admin pages that are reachable via the sidebar. \`navigate\` is only for pages not in the sidebar (e.g. post editor, a specific settings subpage).
   After \`wpAdminMenuClick\`, always emit \`waitForSelector\` on a landmark element of the destination page (e.g. \`#wpbody\`).
+  Exception: \`"Add Post"\` and \`"Add Page"\` land in the block editor — do NOT use \`waitForSelector: "#wpbody"\` for those items because \`#wpbody\` may be hidden by fullscreen mode depending on user preferences or blueprint configuration. Use \`waitForSelector\` with \`[aria-label="Editor top bar"]\` instead, which is always present regardless of fullscreen state. For \`"Add Page"\`, also emit \`tryClick\` with \`role: "button"\`, \`name: "Close"\`, and \`timeout: 5000\` after the waitForSelector, to dismiss the pattern chooser dialog that may appear.
+  Exception: \`"Theme File Editor"\` and \`"Plugin File Editor"\` may show a security warning overlay — emit \`tryClick\` with selector \`#file-editor-warning .file-editor-warning-dismiss\` and \`timeout: 5000\` immediately after the \`wpAdminMenuClick\` (it silently skips if the warning was suppressed via blueprint), then emit \`waitForSelector: "#wpbody"\`.
+
+  **Exact admin menu labels** — use these verbatim, including capitalisation:
+
+  | Section | Top-level \`item\` | Submenu \`item\` values |
+  |---|---|---|
+  | Dashboard | \`"Dashboard"\` | \`"Home"\`, \`"Updates"\` |
+  | Posts | \`"Posts"\` | \`"All Posts"\`, \`"Add Post"\`, \`"Categories"\`, \`"Tags"\` |
+  | Media | \`"Media"\` | \`"Library"\`, \`"Add Media File"\` |
+  | Pages | \`"Pages"\` | \`"All Pages"\`, \`"Add Page"\` |
+  | Comments | \`"Comments"\` | _(no submenu)_ |
+  | Appearance | \`"Appearance"\` | \`"Themes"\`, \`"Editor"\` |
+  | Plugins | \`"Plugins"\` | \`"Installed Plugins"\`, \`"Add Plugin"\` |
+  | Users | \`"Users"\` | \`"All Users"\`, \`"Add User"\`, \`"Profile"\` |
+  | Tools | \`"Tools"\` | \`"Available Tools"\`, \`"Import"\`, \`"Export"\`, \`"Site Health"\`, \`"Export Personal Data"\`, \`"Erase Personal Data"\`, \`"Theme File Editor"\`, \`"Plugin File Editor"\` |
+  | Settings | \`"Settings"\` | \`"General"\`, \`"Writing"\`, \`"Reading"\`, \`"Discussion"\`, \`"Permalinks"\`, \`"Privacy"\` |
+
+  For **Settings → Media**, use \`navigate\` with \`/wp-admin/options-media.php\` — the label "Media" is ambiguous with the top-level Media menu item.
 
 **Block toolbar buttons** (Bold, Italic, Link, Align text, etc.):
   Use \`highlightClick\` with selector \`[role="toolbar"][aria-label="Block tools"] button[aria-label="<ButtonName>"]\`
@@ -165,9 +184,11 @@ After navigating to new-post or new-page, always emit \`tryClick\` with selector
   Emit \`press\` key \`"Meta+k"\`, then \`waitForSelector\` selector \`[role="combobox"]\`, then \`slowType\` on \`[role="combobox"]\`, then \`press\` key \`"Enter"\`.
 
 ### WordPress-specific (prefer these when intent is WordPress-related)
-- tryClick: { "action": "tryClick", "selector": "string", "timeout"?: number } — clicks an element only if it appears within timeout; silently skips if absent. Use for optional UI like welcome dialogs.
+- tryClick: { "action": "tryClick", "selector"?: "string", "role"?: "button"|"link"|etc, "name"?: "string", "exact"?: boolean, "timeout"?: number } — clicks an element only if it appears within timeout; silently skips if absent. Use either \`selector\` (CSS) or \`role\`+\`name\` (accessible role). Use for optional UI like welcome dialogs.
 - wpOpenOptionsMenu: { "action": "wpOpenOptionsMenu", "selector": "button[aria-label=\"<Panel> options\"]" } — opens a sidebar panel's options (⋮) menu; skips the click if the menu is already open. ALWAYS use this instead of highlightClick when opening an options menu.
 - wpAdminMenuClick: { "action": "wpAdminMenuClick", "item": "string" } — clicks an admin sidebar menu item by exact label; works for built-in and plugin/theme custom items
+- wpEditorWPMenuClick: { "action": "wpEditorWPMenuClick" } — clicks the WordPress logo button at the top-left of the block editor header; use to open the editor's back/navigation menu
+- wpEditorToggleFullscreen: { "action": "wpEditorToggleFullscreen", "enable"?: boolean } — opens Editor Options → Preferences and sets Fullscreen mode; pass \`enable: false\` to turn fullscreen off, which reveals the WP admin sidebar without leaving the editor
 - wpInstallPlugin: { "action": "wpInstallPlugin", "slug": "plugin-slug", "activate"?: boolean }
 - wpInstallTheme: { "action": "wpInstallTheme", "slug": "theme-slug", "name"?: "Display Name", "activate"?: boolean }
 - wpSelectBlock: { "action": "wpSelectBlock", "blockType": "paragraph"|"heading"|"image"|etc, "index"?: number }
@@ -188,7 +209,7 @@ After navigating to new-post or new-page, always emit \`tryClick\` with selector
 - Use wpInstallPlugin for installing plugins — derive the slug from the plugin name (lowercase, hyphens); if no plugin is specified, default to slug "gutenberg" (Gutenberg)
 - Use wpInstallTheme for installing themes — derive the slug from the theme name (lowercase, hyphens); pass name only when the display name differs from the title-cased slug; if no theme is specified, default to slug "blockbase" (Blockbase)
 - For WordPress admin navigation, use navigate with the URL path from the WordPress Admin URLs table; always set waitUntil: "domcontentloaded"
-- After navigating to new-post or new-page, emit tryClick with selector .components-modal__header button[aria-label="Close"] to dismiss the welcome dialog
+- After navigating to new-post or new-page, emit tryClick with role "button", name "Close", and timeout 5000 to dismiss the welcome dialog
 - Include waitForSelector before interacting with elements that may not be immediately present
 - When entering the block editor, frameLocator to 'iframe[name="editor-canvas"]' MUST come first — before any waitForSelector, click, fill, or type that targets editor content. exitFrame after.
 - To insert a block, choose based on user intent: use wpInsertBlock (slash-command UI) when the user says "type", "insert", "add", "write", or implies a visible on-screen action; use wpInsertBlockProgrammatic when the user says "programmatically", "silently", "in the background", "set up", or "pre-populate" — invisible, no UI interaction shown in the recording
@@ -197,6 +218,8 @@ After navigating to new-post or new-page, always emit \`tryClick\` with selector
 - To set/replace/update block content, use wpSetBlockContent — it triple-clicks to select all existing text first (replace:true by default); only pass replace:false when the intent is to append
 - To save changes in the site editor, use wpSiteEditorSave — do NOT use generic click on the Save button
 - For ANY navigation to an admin page reachable via the sidebar (Posts, Pages, Media, Comments, Appearance, Plugins, Users, Tools, Settings, Dashboard, or custom plugin/theme items), ALWAYS use wpAdminMenuClick — never use navigate for these; navigate is only for pages not in the sidebar such as the post editor or specific settings subpages
+- When using wpAdminMenuClick, the \`item\` value MUST match the exact label from the admin menu labels table — common mistakes: use \`"Add Post"\` not \`"Add New Post"\`; \`"Add Page"\` not \`"Add New Page"\`; \`"Add Media File"\` not \`"Add New Media File"\`; \`"Add Plugin"\` not \`"Add New Plugin"\`; \`"Add User"\` not \`"Add New User"\`
+- After navigating to the block editor (Add Post, Add Page), the WP admin sidebar is hidden (fullscreen mode). To restore it, emit wpEditorToggleFullscreen with enable:false followed by waitForSelector on #adminmenu. To navigate back via the editor UI instead, emit wpEditorWPMenuClick.
 - To interact with block formatting toolbar (Bold, Italic, alignment, etc.), use highlightClick with selector [role="toolbar"][aria-label="Block tools"] button[aria-label="<ButtonName>"]
 - To open sidebar panels like Categories or Tags, use wpInspectorPanel — it opens the sidebar automatically if needed
 - Collapsed meta boxes in the classic editor render with .postbox.closed by default — click the .postbox-header button to expand, then waitForSelector on the revealed content before interacting


### PR DESCRIPTION
## Summary

- **`wpAdminMenuClick`**: now supports submenu items (e.g. Dashboard → Updates, Posts → Categories) and calls `waitForLoadState('domcontentloaded')` after each click so subsequent steps don't race against navigation
- **`tryClick`**: accepts `role`/`name` as an alternative to a CSS `selector`, enabling role-based lookups like `{ role: "button", name: "Close" }`
- **Sidebar reopen guard**: the post-step logic that reopens the editor Settings panel now checks whether the Settings button is still on the page before clicking, preventing timeouts when navigating away from the editor
- **Test timeout**: increased from 120s to 300s to accommodate the full admin sidebar walkthrough with `slowMo: 500`
- **`claude.js`**: added admin menu labels reference table, exception rules for Add Post/Add Page (use `[aria-label="Editor top bar"]` not `#wpbody`), pattern chooser dismiss rule for Add Page, file editor warning dismiss rule for Theme/Plugin File Editor, and `tryClick` role/name docs
- **Tools menu**: added Theme File Editor and Plugin File Editor; removed Plugin Editor from Plugins

## Test plan

- [ ] Run `npm run record:action -- "Admin Sidebar: Full"` — should pass
- [ ] Run `npm run record:action -- "Admin Sidebar"` — all 5 variants should pass