### PR TITLE
Add step-level preview controls: start-from, always-run, and overflow menu

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -198,6 +198,8 @@ let lastScreencastVideoUri = '';
 let savedScripts = [];
 /** @type {Array<{name: string, filename: string, actionCount: number, builtin: boolean}>} */
 let libraryEntries = [];
+/** @type {number|null} Index into directions[] from which Preview will start; null = run all */
+let startFromIndex = null;
 
 // ── Step descriptions ─────────────────────────────────────────────────────────
 const WP_SCREENS = {
@@ -274,6 +276,76 @@ let activePicker = null;
 /** Remove the floating direction picker from the DOM and clear `activePicker`. */
 function closeDirectionPicker() {
   if (activePicker) { activePicker.remove(); activePicker = null; }
+}
+
+// ── Step overflow menu ────────────────────────────────────────────────────────
+/** @type {HTMLElement|null} */
+let activeStepMenu = null;
+
+function closeStepMenu() {
+  if (activeStepMenu) { activeStepMenu.remove(); activeStepMenu = null; }
+}
+
+/**
+ * Show the floating overflow menu for a direction group.
+ * Contains: expand/collapse, insert direction, save as direction, delete.
+ */
+function showStepMenu(groupIndex, anchorEl) {
+  closeStepMenu();
+  closeDirectionPicker();
+
+  const group = directions[groupIndex];
+  const isOpen = !!group._open;
+
+  const menu = document.createElement('div');
+  menu.className = 'direction-menu';
+  menu.innerHTML = `
+    <button class="direction-menu-item direction-menu-toggle">
+      ${isOpen ? '&#9650; Hide steps' : '&#9660; Show steps'}
+    </button>
+    <button class="direction-menu-item direction-menu-insert">&#43; Insert direction</button>
+    ${!group._fromDirection ? '<button class="direction-menu-item direction-menu-save">&#128190; Save direction</button>' : ''}
+    <div class="direction-menu-divider"></div>
+    <button class="direction-menu-item direction-menu-item--danger direction-menu-delete">&#10005; Delete step</button>
+  `;
+
+  menu.querySelector('.direction-menu-toggle').addEventListener('click', (e) => {
+    e.stopPropagation();
+    directions[groupIndex]._open = !directions[groupIndex]._open;
+    closeStepMenu();
+    renderDirectionList();
+  });
+
+  menu.querySelector('.direction-menu-insert').addEventListener('click', (e) => {
+    e.stopPropagation();
+    closeStepMenu();
+    showDirectionPicker(groupIndex, anchorEl);
+  });
+
+  menu.querySelector('.direction-menu-save')?.addEventListener('click', (e) => {
+    e.stopPropagation();
+    saveDirection(groupIndex);
+    closeStepMenu();
+  });
+
+  menu.querySelector('.direction-menu-delete').addEventListener('click', (e) => {
+    e.stopPropagation();
+    directions.splice(groupIndex, 1);
+    closeStepMenu();
+    renderDirections();
+  });
+
+  document.body.appendChild(menu);
+
+  const rect = anchorEl.getBoundingClientRect();
+  const menuW = 200;
+  let left = rect.right + window.scrollX - menuW;
+  if (left < 8) left = 8;
+  menu.style.top = `${rect.bottom + window.scrollY + 4}px`;
+  menu.style.left = `${left}px`;
+
+  activeStepMenu = menu;
+  setTimeout(() => document.addEventListener('click', closeStepMenu, { once: true }), 0);
 }
 
 /**
@@ -361,6 +433,7 @@ function renderDirectionList() {
   stepList.innerHTML = '';
   emptyHint.style.display = directions.length ? 'none' : '';
   recordBtn.disabled = directions.length === 0;
+  recordBtn.title = startFromIndex !== null ? 'Record full script (preview start point ignored)' : 'Record';
   previewBtn.disabled = directions.length === 0;
   saveBtn.disabled = directions.length === 0;
   exportTxtBtn.disabled = directions.length === 0;
@@ -374,6 +447,13 @@ function renderDirectionList() {
     li.className = 'direction-group';
     li.draggable = true;
 
+    const isStartFrom = startFromIndex === i;
+    const isAlwaysRun = !!group.alwaysRun;
+    const isSkipped   = startFromIndex !== null && i < startFromIndex && !isAlwaysRun;
+    if (isStartFrom)  li.classList.add('start-from');
+    if (isSkipped)    li.classList.add('skipped');
+    if (isAlwaysRun)  li.classList.add('always-run');
+
     const innerHTML = isOpen && innerActions.length > 0
       ? `<ul class="direction-inner-list">${innerActions.map(s => `<li class="direction-inner-item">${ea(describePlain(s))}</li>`).join('')}</ul>`
       : '';
@@ -383,34 +463,28 @@ function renderDirectionList() {
         <span class="drag-handle" title="Drag to reorder">⠿</span>
         <span class="index">${i + 1}</span>
         <input class="direction-label-input" data-group="${i}" value="${ea(group.label)}" title="Edit label">
-        <button class="direction-toggle" aria-expanded="${isOpen}" title="${isOpen ? 'Collapse' : 'Expand'} Playwright steps">${isOpen ? '▼' : '▶'}</button>
-        <button class="direction-insert" title="Insert direction">+</button>
-        ${!group._fromDirection ? '<button class="direction-save" title="Save as direction">&#128204;</button>' : ''}
-        <button class="direction-delete" title="Delete step">✕</button>
+        <button class="direction-start-btn" title="${isStartFrom ? 'Clear preview start point' : 'Preview from this step'}">▷</button>
+        <button class="direction-pin-btn" title="${isAlwaysRun ? 'Remove always-run' : 'Always run (even when skipping earlier steps)'}">📌</button>
+        <button class="direction-menu-btn" title="More actions">⋯</button>
       </div>
       ${innerHTML}
     `;
 
-    li.querySelector('.direction-toggle').addEventListener('click', (e) => {
+    li.querySelector('.direction-start-btn').addEventListener('click', (e) => {
       e.stopPropagation();
-      directions[i]._open = !directions[i]._open;
+      startFromIndex = (startFromIndex === i) ? null : i;
       renderDirectionList();
     });
 
-    li.querySelector('.direction-delete').addEventListener('click', (e) => {
+    li.querySelector('.direction-pin-btn').addEventListener('click', (e) => {
       e.stopPropagation();
-      directions.splice(i, 1);
-      renderDirections();
+      directions[i].alwaysRun = !directions[i].alwaysRun;
+      renderDirectionList();
     });
 
-    li.querySelector('.direction-insert').addEventListener('click', (e) => {
+    li.querySelector('.direction-menu-btn').addEventListener('click', (e) => {
       e.stopPropagation();
-      showDirectionPicker(i, /** @type {HTMLElement} */(e.currentTarget));
-    });
-
-    li.querySelector('.direction-save')?.addEventListener('click', (e) => {
-      e.stopPropagation();
-      saveDirection(i);
+      showStepMenu(i, /** @type {HTMLElement} */(e.currentTarget));
     });
 
     li.querySelector('.direction-label-input').addEventListener('change', (e) => {
@@ -785,11 +859,13 @@ async function runActions() {
  */
 async function runPreview() {
   const name = nameInput.value.trim() || `preview-${Date.now()}`;
+  const body = { name, actions: directionsForJSON(), blueprint, videoSize: null, preview: true };
+  if (startFromIndex !== null && startFromIndex > 0) body.startFrom = startFromIndex;
   await streamRun(
     fetch('/api/run', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, actions: directionsForJSON(), blueprint, videoSize: null, preview: true }),
+      body: JSON.stringify(body),
     }),
     { onDone: () => {} }
   );

--- a/public/app.js
+++ b/public/app.js
@@ -200,6 +200,8 @@ let savedScripts = [];
 let libraryEntries = [];
 /** @type {number|null} Index into directions[] from which Preview will start; null = run all */
 let startFromIndex = null;
+/** @type {Set<number>} Indices of steps that always run even when earlier steps are skipped (session-only, not persisted) */
+let alwaysRunIndices = new Set();
 
 // ── Step descriptions ─────────────────────────────────────────────────────────
 const WP_SCREENS = {
@@ -448,7 +450,7 @@ function renderDirectionList() {
     li.draggable = true;
 
     const isStartFrom = startFromIndex === i;
-    const isAlwaysRun = !!group.alwaysRun;
+    const isAlwaysRun = alwaysRunIndices.has(i);
     const isSkipped   = startFromIndex !== null && i < startFromIndex && !isAlwaysRun;
     if (isStartFrom)  li.classList.add('start-from');
     if (isSkipped)    li.classList.add('skipped');
@@ -478,7 +480,8 @@ function renderDirectionList() {
 
     li.querySelector('.direction-pin-btn').addEventListener('click', (e) => {
       e.stopPropagation();
-      directions[i].alwaysRun = !directions[i].alwaysRun;
+      if (alwaysRunIndices.has(i)) alwaysRunIndices.delete(i);
+      else alwaysRunIndices.add(i);
       renderDirectionList();
     });
 
@@ -541,7 +544,14 @@ function renderDirectionList() {
  */
 function directionsForJSON() {
   // eslint-disable-next-line no-unused-vars
-  return directions.map(({ _open, _fromDirection, ...rest }) => rest);
+  return directions.map(({ _open, _fromDirection, alwaysRun: _alwaysRun, ...rest }) => rest);
+}
+
+/** Like directionsForJSON but re-injects alwaysRun from session state for run/preview calls. */
+function directionsForRun() {
+  return directionsForJSON().map((d, i) =>
+    alwaysRunIndices.has(i) ? { ...d, alwaysRun: true } : d
+  );
 }
 
 /**
@@ -847,7 +857,7 @@ async function runActions() {
     fetch('/api/run', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, actions: directionsForJSON(), blueprint, videoSize: getVideoSize(), endPause: getEndPause() }),
+      body: JSON.stringify({ name, actions: directionsForRun(), blueprint, videoSize: getVideoSize(), endPause: getEndPause() }),
     }),
     { onDone: (msg) => { if (!msg.stopped) loadRecordings(); } }
   );
@@ -859,7 +869,7 @@ async function runActions() {
  */
 async function runPreview() {
   const name = nameInput.value.trim() || `preview-${Date.now()}`;
-  const body = { name, actions: directionsForJSON(), blueprint, videoSize: null, preview: true };
+  const body = { name, actions: directionsForRun(), blueprint, videoSize: null, preview: true };
   if (startFromIndex !== null && startFromIndex > 0) body.startFrom = startFromIndex;
   await streamRun(
     fetch('/api/run', {
@@ -937,6 +947,8 @@ function renderSavedScripts(recordings) {
       const recording = savedScripts.find(s => s.name === name);
       if (!recording) return;
       directions = normalizeActions(recording.directions ?? recording.actions ?? recording.steps ?? []);
+      startFromIndex = null;
+      alwaysRunIndices = new Set();
       nameInput.value = recording.name;
       const secs = ((recording.endPause ?? 2000) / 1000).toString();
       endPauseInput.value = secs;

--- a/public/style.css
+++ b/public/style.css
@@ -259,6 +259,62 @@ header p {
 
 #step-list li.direction-group.dragging { opacity: 0.4; }
 #step-list li.direction-group.drag-over { border-color: #6366f1; background: #1e2248; }
+#step-list li.direction-group.start-from { border-color: #16a34a; background: #0f2a1a; }
+#step-list li.direction-group.start-from .direction-start-btn { color: #4ade80; }
+#step-list li.direction-group.skipped { opacity: 0.35; }
+#step-list li.direction-group.always-run { border-left: 3px solid #f59e0b; }
+#step-list li.direction-group.always-run .direction-pin-btn { color: #f59e0b; }
+#step-list li.direction-group.skipped.always-run { opacity: 1; }
+
+.direction-start-btn,
+.direction-pin-btn,
+.direction-menu-btn {
+  background: none;
+  border: none;
+  color: #374151;
+  cursor: pointer;
+  font-size: 0.7rem;
+  padding: 0.2rem 0.3rem;
+  border-radius: 3px;
+  transition: color 0.15s, background 0.15s;
+  flex-shrink: 0;
+}
+.direction-start-btn:hover { color: #4ade80; background: #0f2a1a; }
+.direction-pin-btn:hover { color: #f59e0b; background: #1f1a0a; }
+.direction-menu-btn:hover { color: #94a3b8; background: #252d3d; }
+
+.direction-menu {
+  position: absolute;
+  z-index: 1000;
+  background: #1a2235;
+  border: 1px solid #2d3a50;
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+  min-width: 180px;
+  padding: 0.3rem 0;
+}
+
+.direction-menu-item {
+  background: none;
+  border: none;
+  color: #cbd5e1;
+  cursor: pointer;
+  display: block;
+  font-size: 0.85rem;
+  padding: 0.45rem 1rem;
+  text-align: left;
+  transition: background 0.1s;
+  white-space: nowrap;
+  width: 100%;
+}
+.direction-menu-item:hover { background: #243046; }
+.direction-menu-item--danger { color: #f87171; }
+.direction-menu-item--danger:hover { background: #2d1f1f; }
+
+.direction-menu-divider {
+  border-top: 1px solid #2d3a50;
+  margin: 0.3rem 0;
+}
 
 .direction-group-header {
   display: flex;

--- a/recordings/run-steps.js
+++ b/recordings/run-steps.js
@@ -402,7 +402,12 @@ async function runSteps(page, def, runner = null) {
   const sidebar = page.getByRole('region', { name: 'Editor settings' });
 
   // Support both grouped format ({ label, actions[] }) and legacy flat/steps format
-  const rawActions = def.actions ?? def.steps ?? [];
+  let rawActions = def.actions ?? def.steps ?? [];
+  if (def.startFrom != null && def.startFrom > 0) {
+    const pinned   = rawActions.slice(0, def.startFrom).filter(g => g.alwaysRun);
+    const fromHere = rawActions.slice(def.startFrom);
+    rawActions = [...pinned, ...fromHere];
+  }
   const flatActions = rawActions.flatMap(s => s.actions ?? s.steps ?? [s]);
 
   for (const step of flatActions) {

--- a/src/routes/runner.js
+++ b/src/routes/runner.js
@@ -192,7 +192,7 @@ function register(app) {
 
   // Single-recording run: write the posted steps to a file and run them directly.
   app.post('/api/run', async (req, res) => {
-    const { name = `recording-${Date.now()}`, actions = [], blueprint = null, videoSize = null, preview = false, endPause } = req.body;
+    const { name = `recording-${Date.now()}`, actions = [], blueprint = null, videoSize = null, preview = false, endPause, startFrom } = req.body;
     if (!actions.length) return res.status(400).json({ error: 'no actions provided' });
 
     if (!fs.existsSync(STEPS_DIR)) fs.mkdirSync(STEPS_DIR);
@@ -216,8 +216,11 @@ function register(app) {
       return;
     }
 
+    const runDef = { ...scriptData };
+    if (startFrom != null && startFrom > 0) runDef.startFrom = startFrom;
+
     await runPlaywrightApi({
-      scripts: [scriptData],
+      scripts: [runDef],
       port,
       videoSize,
       send,


### PR DESCRIPTION
## Summary

- **Preview start point** — click ▷ on any step to start Preview from there; skipped steps dim visually. Record always runs the full script.
- **Always-run pinning** — 📌 marks a step to always execute (even when skipping earlier steps), useful for setup steps like login or navigation. This state is session-only and never saved to the script JSON.
- **Step header overflow menu** — secondary actions (show/hide steps, insert direction, save direction, delete) consolidated into a ⋯ menu; delete gets danger styling.

Closes [DEVREL-1372](https://linear.app/a8c/issue/DEVREL-1372)

## Test plan
- [ ] Add 4+ steps; click ▷ on step 3 → steps 1–2 dim, step 3 gets green border
- [ ] Click ▷ again → clears, all steps normal
- [ ] Click Preview with step 3 selected → only steps 3+ execute
- [ ] Click Record with start point set → full script runs, tooltip says "Record full script (preview start point ignored)"
- [ ] Pin step 1 with 📌, set start to step 3 → step 1 runs first, then step 3+
- [ ] Pin a step, save the script, reload the page and load the script → pinned step has no 📌 (always-run does not persist)
- [ ] Pin a step on one script, then load a different script → pin is cleared (always-run resets on script load)
- [ ] Open ⋯ menu → shows Show/Hide steps, Insert direction, Save direction, Delete
- [ ] Delete via ⋯ menu works; save direction and insert direction work