### PR TITLE
Add step progress indicator during recording runs

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -776,6 +776,10 @@ async function readSSE(res, onDone) {
         if (msg.type === 'stdout' || msg.type === 'stderr') {
           logOutput.textContent += msg.text;
           logOutput.scrollTop = logOutput.scrollHeight;
+        } else if (msg.type === 'step-progress') {
+          const items = stepList.querySelectorAll('li.direction-group');
+          items.forEach((el, i) => el.classList.toggle('active-step', i === msg.index));
+          items[msg.index]?.scrollIntoView({ block: 'nearest' });
         } else if (msg.type === 'screencast') {
           previewImg.src = `data:image/jpeg;base64,${msg.data}`;
           previewPlaceholder.hidden = true;
@@ -784,6 +788,7 @@ async function readSSE(res, onDone) {
         } else if (msg.type === 'screencastVideo') {
           lastScreencastVideoUri = msg.uri;
         } else if (msg.type === 'done') {
+          stepList.querySelectorAll('li.direction-group.active-step').forEach(el => el.classList.remove('active-step'));
           onDone(msg);
         }
       } catch {}

--- a/public/style.css
+++ b/public/style.css
@@ -265,6 +265,30 @@ header p {
 #step-list li.direction-group.always-run { border-left: 3px solid #f59e0b; }
 #step-list li.direction-group.always-run .direction-pin-btn { color: #f59e0b; }
 #step-list li.direction-group.skipped.always-run { opacity: 1; }
+#step-list li.direction-group.active-step {
+  border-color: #6366f1;
+  background: #1e1f3b;
+  box-shadow: 0 0 0 2px rgba(99,102,241,0.35);
+}
+#step-list li.direction-group.active-step .index {
+  position: relative;
+  color: transparent;
+}
+#step-list li.direction-group.active-step .index::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 6px;
+  height: 6px;
+  background: #818cf8;
+  border-radius: 50%;
+  animation: step-pulse 1s ease-in-out infinite;
+}
+@keyframes step-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%       { opacity: 0.4; transform: scale(0.7); }
+}
 
 .direction-start-btn,
 .direction-pin-btn,

--- a/recordings/run-steps.js
+++ b/recordings/run-steps.js
@@ -393,29 +393,40 @@ async function runStep(step, page, frameStack, ctx, sidebar) {
  *   Optional wrapper called around each step, receiving the step object and an
  *   async executor — e.g. Playwright's `test.step()` for named reporting.
  *   When null, steps run unwrapped.
+ * @param {((index: number, total: number) => void)|null} [onStepStart]
+ *   Called before each direction group begins executing, with its original
+ *   index in the full actions array and the total group count.
  * @returns {Promise<void>}
  */
-async function runSteps(page, def, runner = null) {
+async function runSteps(page, def, runner = null, onStepStart = null) {
   // Frame context stack: top of stack is the active locator context
   const frameStack = [page];
   const ctx = () => frameStack[frameStack.length - 1];
   const sidebar = page.getByRole('region', { name: 'Editor settings' });
 
   // Support both grouped format ({ label, actions[] }) and legacy flat/steps format
-  let rawActions = def.actions ?? def.steps ?? [];
-  if (def.startFrom != null && def.startFrom > 0) {
-    const pinned   = rawActions.slice(0, def.startFrom).filter(g => g.alwaysRun);
-    const fromHere = rawActions.slice(def.startFrom);
-    rawActions = [...pinned, ...fromHere];
-  }
-  const flatActions = rawActions.flatMap(s => s.actions ?? s.steps ?? [s]);
+  const allActions = def.actions ?? def.steps ?? [];
+  const total = allActions.length;
 
-  for (const step of flatActions) {
-    await (
-      runner
-      ? runner(step, async () => await runStep( step, page, frameStack, ctx, sidebar ))
-      : runStep( step, page, frameStack, ctx, sidebar )
-    );
+  // Preserve original indices through the startFrom filter so the UI can
+  // highlight the correct direction group regardless of what was skipped.
+  let toRun = allActions.map((group, i) => ({ group, origIndex: i }));
+  if (def.startFrom != null && def.startFrom > 0) {
+    const pinned   = toRun.slice(0, def.startFrom).filter(({ group: g }) => g.alwaysRun);
+    const fromHere = toRun.slice(def.startFrom);
+    toRun = [...pinned, ...fromHere];
+  }
+
+  for (const { group, origIndex } of toRun) {
+    onStepStart?.(origIndex, total);
+    const groupSteps = group.actions ?? group.steps ?? [group];
+    for (const step of groupSteps) {
+      await (
+        runner
+        ? runner(step, async () => await runStep( step, page, frameStack, ctx, sidebar ))
+        : runStep( step, page, frameStack, ctx, sidebar )
+      );
+    }
   }
 
   await page.waitForTimeout(def.endPause ?? DEFAULT_END_PAUSE);

--- a/src/routes/runner.js
+++ b/src/routes/runner.js
@@ -148,7 +148,9 @@ async function runPlaywrightApi({ scripts, port, videoSize, send, doneExtra = {}
         quality: 80,
         size: { width: 1280, height: 720 },
       });
-      await runSteps(page, def);
+      await runSteps(page, def, null, (index, total) => {
+        send({ type: 'step-progress', index, total });
+      });
       await page.screencast.stop();
 
       const video = page.video();


### PR DESCRIPTION
## Summary

- Emits a new `step-progress` SSE event (`{ type, index, total }`) from the server before each direction group executes
- `readSSE` in the UI handles the event by toggling an `active-step` CSS class on the matching `li.direction-group` and scrolling it into view
- On `done`, all `active-step` highlights are cleared
- Visual treatment: indigo border + glow on the active row; the step number is replaced by a small pulsing dot while running

Closes: [DEVREL-1373](https://linear.app/a8c/issue/DEVREL-1373/show-active-step-indicator-in-script-while-previewing-or-recording)

This should be merged after #25 as it builds on the work in that PR.

## Dependencies

Stacked on top of `devrel-1372-step-level-preview-controls` — that branch must merge first.

## Signal chain

```
runSteps() [run-steps.js]
  → onStepStart(origIndex, total) callback
    → send({ type: 'step-progress', index, total }) [runner.js]
      → readSSE handler toggles .active-step on li.direction-group[index] [app.js]
```

The `origIndex` is preserved through the `startFrom` filter so pinned (`alwaysRun`) steps and steps after the start point highlight the correct row in the UI regardless of which steps were skipped.

## Test plan

- [ ] Start a recording run and confirm the active step highlights and advances through the list
- [ ] Verify the highlight clears on completion
- [ ] Test with `startFrom` set — confirm pinned steps highlight at their original position, then execution continues from the start-from row
- [ ] Confirm the pulsing dot appears in the step number slot and disappears after the run