### PR TITLE
DEVREL-1393: Disable loading scripts while running a recording/preview

### DIFF
--- a/client/Sidebar/SavedScriptsPanel.jsx
+++ b/client/Sidebar/SavedScriptsPanel.jsx
@@ -67,10 +67,15 @@ export function SavedScriptsPanel() {
               <span className="script-meta">
                 {script.directionCount} direction{script.directionCount !== 1 ? 's' : ''}
               </span>
-              <button className="script-load-btn secondary" type="button" onClick={() => {
-                loadScriptIntoEditor(script);
-                toast.success(`Loaded "${script.name}"`);
-              }}>
+              <button
+                className="script-load-btn secondary"
+                type="button"
+                disabled={running}
+                onClick={() => {
+                  loadScriptIntoEditor(script);
+                  toast.success(`Loaded "${script.name}"`);
+                }}
+              >
                 Load
               </button>
               <button className="script-delete-btn danger" type="button" onClick={() => deleteScript(script)}>

--- a/public/style.css
+++ b/public/style.css
@@ -999,6 +999,17 @@ header p {
 
 .saved-script-item .script-load-btn:hover { border-color: #6b7280; color: #e2e8f0; }
 
+.saved-script-item .script-load-btn:disabled {
+  border-color: #2d3748;
+  color: #374151;
+  cursor: not-allowed;
+}
+
+.saved-script-item .script-load-btn:disabled:hover {
+  border-color: #2d3748;
+  color: #374151;
+}
+
 .saved-script-item .script-delete-btn {
   background: transparent;
   border: 1px solid #4b1c1c;


### PR DESCRIPTION
DEVREL-1393

Disable the "Load" button when we're running a recording or a preview as it doesn't make sense to keep it available as you can mess things up in weird ways.