### PR TITLE
DEVREL-1405: Reorganize directions+blueprint+recording settings into a tabbed section

### DIFF
--- a/client/DirectionGroup.jsx
+++ b/client/DirectionGroup.jsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { describePlain } from './utils/actions.js';
 
 export function DirectionGroup({
@@ -25,17 +26,17 @@ export function DirectionGroup({
   const isTranslating = translationStatus === 'pending';
   const isTranslationError = translationStatus === 'error';
   const isResolved = !translationStatus || translationStatus === 'resolved';
-  const className = [
+  const className = clsx(
     'direction-group',
-    dragging ? 'dragging' : '',
-    dragOver ? 'drag-over' : '',
-    isActiveStep ? 'active-step' : '',
-    isStartFrom ? 'start-from' : '',
-    isSkipped ? 'skipped' : '',
-    isAlwaysRun ? 'always-run' : '',
-    isTranslating ? 'is-translating' : '',
-    isTranslationError ? 'has-translation-error' : '',
-  ].filter(Boolean).join(' ');
+    dragging && 'dragging',
+    dragOver && 'drag-over',
+    isActiveStep && 'active-step',
+    isStartFrom && 'start-from',
+    isSkipped && 'skipped',
+    isAlwaysRun && 'always-run',
+    isTranslating && 'is-translating',
+    isTranslationError && 'has-translation-error',
+  );
 
   return (
     <li

--- a/client/DirectionPicker.jsx
+++ b/client/DirectionPicker.jsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useState } from 'react';
 
 export function DirectionPicker({ anchorIndex, entries, onClose, onSelect, position }) {
@@ -20,14 +21,14 @@ export function DirectionPicker({ anchorIndex, entries, onClose, onSelect, posit
         <>
           <div className="direction-picker-position">
             <button
-              className={`direction-picker-pos-btn${!insertAbove ? ' active' : ''}`}
+              className={clsx('direction-picker-pos-btn', !insertAbove && 'active')}
               type="button"
               onClick={() => setInsertAbove(false)}
             >
               &#8595; Below
             </button>
             <button
-              className={`direction-picker-pos-btn${insertAbove ? ' active' : ''}`}
+              className={clsx('direction-picker-pos-btn', insertAbove && 'active')}
               type="button"
               onClick={() => setInsertAbove(true)}
             >
@@ -41,7 +42,7 @@ export function DirectionPicker({ anchorIndex, entries, onClose, onSelect, posit
       {entries.map((entry) => (
         <button
           key={entry.filename}
-          className={`direction-picker-item${entry.builtin ? ' direction-picker-item--builtin' : ''}`}
+          className={clsx('direction-picker-item', entry.builtin && 'direction-picker-item--builtin')}
           type="button"
           onClick={() => selectEntry(entry.filename)}
         >

--- a/client/DirectionsPanel.jsx
+++ b/client/DirectionsPanel.jsx
@@ -4,6 +4,8 @@ import { useAppState } from './context/AppStateContext.jsx';
 import { DirectionGroup } from './DirectionGroup.jsx';
 import { DirectionMenu } from './DirectionMenu.jsx';
 import { DirectionPicker } from './DirectionPicker.jsx';
+import { BlueprintPanel } from './Sidebar/BlueprintPanel.jsx';
+import { RecordingSettingsPanel } from './Sidebar/RecordingSettingsPanel.jsx';
 import { directionsForJSON, errorMessage, flattenDirectionActions } from './utils/actions.js';
 import {
   useDirectionLoader,
@@ -54,6 +56,7 @@ export function DirectionsPanel() {
   const [dragOverIndex, setDragOverIndex] = useState(null);
   const [menu, setMenu] = useState(null);
   const [picker, setPicker] = useState(null);
+  const [activeTab, setActiveTab] = useState('directions');
   const loadDirection = useDirectionLoader();
   const saveDirectionMutation = useSaveDirectionMutation();
 
@@ -61,6 +64,10 @@ export function DirectionsPanel() {
     setMenu(null);
     setPicker(null);
   }, []);
+  const selectTab = useCallback((tab) => {
+    closePopovers();
+    setActiveTab(tab);
+  }, [closePopovers]);
   const activeDirectionRef = useCallback((node) => {
     if (node) node.scrollIntoView({ block: 'nearest' });
   }, []);
@@ -98,110 +105,173 @@ export function DirectionsPanel() {
 
   return (
     <div className="panel" id="directions-panel">
-      <div className="panel-header">
-        <h2>Directions <span id="step-count">({directions.length})</span></h2>
-        <button
-          className="view-toggle-btn"
-          type="button"
-          hidden={!hasDirections}
-          onClick={() => setDirectionsView(directionsView === 'actions' ? 'json' : 'actions')}
-        >
-          {directionsView === 'actions' ? 'Show JSON' : 'Show Actions'}
-        </button>
+      <div className="script-settings-header">
+        <div className="script-settings-tabs" role="tablist" aria-label="Script settings">
+          <button
+            id="script-tab-directions"
+            className={`script-settings-tab${activeTab === 'directions' ? ' active' : ''}`}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === 'directions'}
+            aria-controls="script-panel-directions"
+            onClick={() => selectTab('directions')}
+          >
+            Directions <span id="step-count">({directions.length})</span>
+          </button>
+          <button
+            id="script-tab-blueprint"
+            className={`script-settings-tab${activeTab === 'blueprint' ? ' active' : ''}`}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === 'blueprint'}
+            aria-controls="script-panel-blueprint"
+            onClick={() => selectTab('blueprint')}
+          >
+            Blueprint
+          </button>
+          <button
+            id="script-tab-recording"
+            className={`script-settings-tab${activeTab === 'recording' ? ' active' : ''}`}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === 'recording'}
+            aria-controls="script-panel-recording"
+            onClick={() => selectTab('recording')}
+          >
+            Recording Settings
+          </button>
+        </div>
+        {activeTab === 'directions' && hasDirections && (
+          <button
+            className="view-toggle-btn"
+            type="button"
+            onClick={() => setDirectionsView(directionsView === 'actions' ? 'json' : 'actions')}
+          >
+            {directionsView === 'actions' ? 'Show JSON' : 'Show Actions'}
+          </button>
+        )}
       </div>
 
-      {directionsView === 'actions' && (
-        <>
-          <ul id="step-list">
-            {directions.map((direction, index) => {
-              const isStartFrom = startFromIndex === index;
-              const isAlwaysRun = alwaysRunIndices.has(index);
-              const isSkipped = startFromIndex !== null && index < startFromIndex && !isAlwaysRun;
+      <div
+        id="script-panel-directions"
+        className="script-settings-tab-panel"
+        role="tabpanel"
+        aria-labelledby="script-tab-directions"
+        hidden={activeTab !== 'directions'}
+      >
+        {directionsView === 'actions' && (
+          <>
+            <ul id="step-list">
+              {directions.map((direction, index) => {
+                const isStartFrom = startFromIndex === index;
+                const isAlwaysRun = alwaysRunIndices.has(index);
+                const isSkipped = startFromIndex !== null && index < startFromIndex && !isAlwaysRun;
 
-              return (
-                <DirectionGroup
-                  key={direction._id ?? index}
-                  direction={direction}
-                  dragging={draggingIndex === index}
-                  dragOver={dragOverIndex === index}
-                  index={index}
-                  isAlwaysRun={isAlwaysRun}
-                  isActiveStep={activeStepIndex === index}
-                  isSkipped={isSkipped}
-                  isStartFrom={isStartFrom}
-                  itemRef={activeStepIndex === index ? activeDirectionRef : null}
-                  onDragStart={(event) => {
-                    if (event.target.tagName === 'INPUT') {
+                return (
+                  <DirectionGroup
+                    key={direction._id ?? index}
+                    direction={direction}
+                    dragging={draggingIndex === index}
+                    dragOver={dragOverIndex === index}
+                    index={index}
+                    isAlwaysRun={isAlwaysRun}
+                    isActiveStep={activeStepIndex === index}
+                    isSkipped={isSkipped}
+                    isStartFrom={isStartFrom}
+                    itemRef={activeStepIndex === index ? activeDirectionRef : null}
+                    onDragStart={(event) => {
+                      if (event.target.tagName === 'INPUT') {
+                        event.preventDefault();
+                        return;
+                      }
+                      draggingIndexRef.current = index;
+                      setDraggingIndex(index);
+                      event.dataTransfer.effectAllowed = 'move';
+                      event.dataTransfer.setData('text/plain', String(index));
+                    }}
+                    onDragEnd={() => {
+                      draggingIndexRef.current = null;
+                      setDraggingIndex(null);
+                      setDragOverIndex(null);
+                    }}
+                    onDragOver={(event) => {
                       event.preventDefault();
-                      return;
-                    }
-                    draggingIndexRef.current = index;
-                    setDraggingIndex(index);
-                    event.dataTransfer.effectAllowed = 'move';
-                    event.dataTransfer.setData('text/plain', String(index));
-                  }}
-                  onDragEnd={() => {
-                    draggingIndexRef.current = null;
-                    setDraggingIndex(null);
-                    setDragOverIndex(null);
-                  }}
-                  onDragOver={(event) => {
-                    event.preventDefault();
-                    event.dataTransfer.dropEffect = 'move';
-                    if (draggingIndexRef.current !== null && draggingIndexRef.current !== index) {
-                      setDragOverIndex(index);
-                    }
-                  }}
-                  onDragLeave={() => {
-                    setDragOverIndex((current) => (current === index ? null : current));
-                  }}
-                  onDrop={(event) => {
-                    event.preventDefault();
-                    const from = draggingIndexRef.current;
-                    if (from !== null && from !== index) {
-                      reorderDirections(from, index);
-                    }
-                    draggingIndexRef.current = null;
-                    setDraggingIndex(null);
-                    setDragOverIndex(null);
-                  }}
-                  onLabelChange={(label) => updateDirectionLabel(index, label)}
-                  onMenu={(event) => {
-                    event.stopPropagation();
-                    setPicker(null);
-                    setMenu({ index, position: menuPosition(event.currentTarget) });
-                  }}
-                  onToggleAlwaysRun={() => toggleAlwaysRun(index)}
-                  onToggleStartFrom={() => toggleStartFrom(index)}
-                />
-              );
-            })}
-          </ul>
+                      event.dataTransfer.dropEffect = 'move';
+                      if (draggingIndexRef.current !== null && draggingIndexRef.current !== index) {
+                        setDragOverIndex(index);
+                      }
+                    }}
+                    onDragLeave={() => {
+                      setDragOverIndex((current) => (current === index ? null : current));
+                    }}
+                    onDrop={(event) => {
+                      event.preventDefault();
+                      const from = draggingIndexRef.current;
+                      if (from !== null && from !== index) {
+                        reorderDirections(from, index);
+                      }
+                      draggingIndexRef.current = null;
+                      setDraggingIndex(null);
+                      setDragOverIndex(null);
+                    }}
+                    onLabelChange={(label) => updateDirectionLabel(index, label)}
+                    onMenu={(event) => {
+                      event.stopPropagation();
+                      setPicker(null);
+                      setMenu({ index, position: menuPosition(event.currentTarget) });
+                    }}
+                    onToggleAlwaysRun={() => toggleAlwaysRun(index)}
+                    onToggleStartFrom={() => toggleStartFrom(index)}
+                  />
+                );
+              })}
+            </ul>
 
-          {!hasDirections && <p id="empty-hint" className="hint">Type a command above, or insert a direction below.</p>}
+            {!hasDirections && <p id="empty-hint" className="hint">Type a command above, or insert a direction below.</p>}
 
-          <div id="direction-insert-bottom">
-            <button
-              className="direction-insert-plus direction-insert-plus--bottom"
-              title="Insert direction"
-              type="button"
-              onClick={(event) => {
-                event.stopPropagation();
-                setMenu(null);
-                setPicker({ anchorIndex: null, position: pickerPosition(event.currentTarget) });
-              }}
-            >
-              + Insert direction
-            </button>
-          </div>
-        </>
-      )}
+            <div id="direction-insert-bottom">
+              <button
+                className="direction-insert-plus direction-insert-plus--bottom"
+                title="Insert direction"
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setMenu(null);
+                  setPicker({ anchorIndex: null, position: pickerPosition(event.currentTarget) });
+                }}
+              >
+                + Insert direction
+              </button>
+            </div>
+          </>
+        )}
 
-      {directionsView === 'json' && (
-        <pre id="steps-json-view">{JSON.stringify(cleanDirections, null, 2)}</pre>
-      )}
+        {directionsView === 'json' && (
+          <pre id="steps-json-view">{JSON.stringify(cleanDirections, null, 2)}</pre>
+        )}
+      </div>
 
-      {menu && directions[menu.index] && (
+      <div
+        id="script-panel-blueprint"
+        className="script-settings-tab-panel"
+        role="tabpanel"
+        aria-labelledby="script-tab-blueprint"
+        hidden={activeTab !== 'blueprint'}
+      >
+        <BlueprintPanel embedded />
+      </div>
+
+      <div
+        id="script-panel-recording"
+        className="script-settings-tab-panel"
+        role="tabpanel"
+        aria-labelledby="script-tab-recording"
+        hidden={activeTab !== 'recording'}
+      >
+        <RecordingSettingsPanel embedded />
+      </div>
+
+      {activeTab === 'directions' && menu && directions[menu.index] && (
         <>
           <button className="popover-backdrop" type="button" aria-label="Close menu" onClick={closePopovers} />
           <DirectionMenu
@@ -216,7 +286,7 @@ export function DirectionsPanel() {
         </>
       )}
 
-      {picker && (
+      {activeTab === 'directions' && picker && (
         <>
           <button className="popover-backdrop" type="button" aria-label="Close direction picker" onClick={closePopovers} />
           <DirectionPicker

--- a/client/DirectionsPanel.jsx
+++ b/client/DirectionsPanel.jsx
@@ -154,123 +154,125 @@ export function DirectionsPanel() {
         )}
       </div>
 
-      <div
-        id="script-panel-directions"
-        className="script-settings-tab-panel"
-        role="tabpanel"
-        aria-labelledby="script-tab-directions"
-        hidden={activeTab !== 'directions'}
-      >
-        {directionsView === 'actions' && (
-          <>
-            <ul id="step-list">
-              {directions.map((direction, index) => {
-                const isStartFrom = startFromIndex === index;
-                const isAlwaysRun = alwaysRunIndices.has(index);
-                const isSkipped = startFromIndex !== null && index < startFromIndex && !isAlwaysRun;
+      <div className="script-settings-scroll">
+        <div
+          id="script-panel-directions"
+          className="script-settings-tab-panel"
+          role="tabpanel"
+          aria-labelledby="script-tab-directions"
+          hidden={activeTab !== 'directions'}
+        >
+          {directionsView === 'actions' && (
+            <>
+              <ul id="step-list">
+                {directions.map((direction, index) => {
+                  const isStartFrom = startFromIndex === index;
+                  const isAlwaysRun = alwaysRunIndices.has(index);
+                  const isSkipped = startFromIndex !== null && index < startFromIndex && !isAlwaysRun;
 
-                return (
-                  <DirectionGroup
-                    key={direction._id ?? index}
-                    direction={direction}
-                    dragging={draggingIndex === index}
-                    dragOver={dragOverIndex === index}
-                    index={index}
-                    isAlwaysRun={isAlwaysRun}
-                    isActiveStep={activeStepIndex === index}
-                    isSkipped={isSkipped}
-                    isStartFrom={isStartFrom}
-                    itemRef={activeStepIndex === index ? activeDirectionRef : null}
-                    onDragStart={(event) => {
-                      if (event.target.tagName === 'INPUT') {
+                  return (
+                    <DirectionGroup
+                      key={direction._id ?? index}
+                      direction={direction}
+                      dragging={draggingIndex === index}
+                      dragOver={dragOverIndex === index}
+                      index={index}
+                      isAlwaysRun={isAlwaysRun}
+                      isActiveStep={activeStepIndex === index}
+                      isSkipped={isSkipped}
+                      isStartFrom={isStartFrom}
+                      itemRef={activeStepIndex === index ? activeDirectionRef : null}
+                      onDragStart={(event) => {
+                        if (event.target.tagName === 'INPUT') {
+                          event.preventDefault();
+                          return;
+                        }
+                        draggingIndexRef.current = index;
+                        setDraggingIndex(index);
+                        event.dataTransfer.effectAllowed = 'move';
+                        event.dataTransfer.setData('text/plain', String(index));
+                      }}
+                      onDragEnd={() => {
+                        draggingIndexRef.current = null;
+                        setDraggingIndex(null);
+                        setDragOverIndex(null);
+                      }}
+                      onDragOver={(event) => {
                         event.preventDefault();
-                        return;
-                      }
-                      draggingIndexRef.current = index;
-                      setDraggingIndex(index);
-                      event.dataTransfer.effectAllowed = 'move';
-                      event.dataTransfer.setData('text/plain', String(index));
-                    }}
-                    onDragEnd={() => {
-                      draggingIndexRef.current = null;
-                      setDraggingIndex(null);
-                      setDragOverIndex(null);
-                    }}
-                    onDragOver={(event) => {
-                      event.preventDefault();
-                      event.dataTransfer.dropEffect = 'move';
-                      if (draggingIndexRef.current !== null && draggingIndexRef.current !== index) {
-                        setDragOverIndex(index);
-                      }
-                    }}
-                    onDragLeave={() => {
-                      setDragOverIndex((current) => (current === index ? null : current));
-                    }}
-                    onDrop={(event) => {
-                      event.preventDefault();
-                      const from = draggingIndexRef.current;
-                      if (from !== null && from !== index) {
-                        reorderDirections(from, index);
-                      }
-                      draggingIndexRef.current = null;
-                      setDraggingIndex(null);
-                      setDragOverIndex(null);
-                    }}
-                    onLabelChange={(label) => updateDirectionLabel(index, label)}
-                    onMenu={(event) => {
-                      event.stopPropagation();
-                      setPicker(null);
-                      setMenu({ index, position: menuPosition(event.currentTarget) });
-                    }}
-                    onToggleAlwaysRun={() => toggleAlwaysRun(index)}
-                    onToggleStartFrom={() => toggleStartFrom(index)}
-                  />
-                );
-              })}
-            </ul>
+                        event.dataTransfer.dropEffect = 'move';
+                        if (draggingIndexRef.current !== null && draggingIndexRef.current !== index) {
+                          setDragOverIndex(index);
+                        }
+                      }}
+                      onDragLeave={() => {
+                        setDragOverIndex((current) => (current === index ? null : current));
+                      }}
+                      onDrop={(event) => {
+                        event.preventDefault();
+                        const from = draggingIndexRef.current;
+                        if (from !== null && from !== index) {
+                          reorderDirections(from, index);
+                        }
+                        draggingIndexRef.current = null;
+                        setDraggingIndex(null);
+                        setDragOverIndex(null);
+                      }}
+                      onLabelChange={(label) => updateDirectionLabel(index, label)}
+                      onMenu={(event) => {
+                        event.stopPropagation();
+                        setPicker(null);
+                        setMenu({ index, position: menuPosition(event.currentTarget) });
+                      }}
+                      onToggleAlwaysRun={() => toggleAlwaysRun(index)}
+                      onToggleStartFrom={() => toggleStartFrom(index)}
+                    />
+                  );
+                })}
+              </ul>
 
-            {!hasDirections && <p id="empty-hint" className="hint">Type a command above, or insert a direction below.</p>}
+              {!hasDirections && <p id="empty-hint" className="hint">Type a command above, or insert a direction below.</p>}
 
-            <div id="direction-insert-bottom">
-              <button
-                className="direction-insert-plus direction-insert-plus--bottom"
-                title="Insert direction"
-                type="button"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  setMenu(null);
-                  setPicker({ anchorIndex: null, position: pickerPosition(event.currentTarget) });
-                }}
-              >
-                + Insert direction
-              </button>
-            </div>
-          </>
-        )}
+              <div id="direction-insert-bottom">
+                <button
+                  className="direction-insert-plus direction-insert-plus--bottom"
+                  title="Insert direction"
+                  type="button"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setMenu(null);
+                    setPicker({ anchorIndex: null, position: pickerPosition(event.currentTarget) });
+                  }}
+                >
+                  + Insert direction
+                </button>
+              </div>
+            </>
+          )}
 
-        {directionsView === 'json' && (
-          <pre id="steps-json-view">{JSON.stringify(cleanDirections, null, 2)}</pre>
-        )}
-      </div>
+          {directionsView === 'json' && (
+            <pre id="steps-json-view">{JSON.stringify(cleanDirections, null, 2)}</pre>
+          )}
+        </div>
 
-      <div
-        id="script-panel-blueprint"
-        className="script-settings-tab-panel"
-        role="tabpanel"
-        aria-labelledby="script-tab-blueprint"
-        hidden={activeTab !== 'blueprint'}
-      >
-        <BlueprintPanel embedded />
-      </div>
+        <div
+          id="script-panel-blueprint"
+          className="script-settings-tab-panel"
+          role="tabpanel"
+          aria-labelledby="script-tab-blueprint"
+          hidden={activeTab !== 'blueprint'}
+        >
+          <BlueprintPanel embedded />
+        </div>
 
-      <div
-        id="script-panel-recording"
-        className="script-settings-tab-panel"
-        role="tabpanel"
-        aria-labelledby="script-tab-recording"
-        hidden={activeTab !== 'recording'}
-      >
-        <RecordingSettingsPanel embedded />
+        <div
+          id="script-panel-recording"
+          className="script-settings-tab-panel"
+          role="tabpanel"
+          aria-labelledby="script-tab-recording"
+          hidden={activeTab !== 'recording'}
+        >
+          <RecordingSettingsPanel embedded />
+        </div>
       </div>
 
       {activeTab === 'directions' && menu && directions[menu.index] && (

--- a/client/DirectionsPanel.jsx
+++ b/client/DirectionsPanel.jsx
@@ -4,6 +4,7 @@ import { useAppState } from './context/AppStateContext.jsx';
 import { DirectionGroup } from './DirectionGroup.jsx';
 import { DirectionMenu } from './DirectionMenu.jsx';
 import { DirectionPicker } from './DirectionPicker.jsx';
+import { PoolStatusIndicators } from './PoolStatusIndicators.jsx';
 import { BlueprintPanel } from './Sidebar/BlueprintPanel.jsx';
 import { RecordingSettingsPanel } from './Sidebar/RecordingSettingsPanel.jsx';
 import { directionsForJSON, errorMessage, flattenDirectionActions } from './utils/actions.js';
@@ -128,6 +129,7 @@ export function DirectionsPanel() {
             onClick={() => selectTab('blueprint')}
           >
             Blueprint
+            <PoolStatusIndicators className="blueprint-pool-indicators--tab" />
           </button>
           <button
             id="script-tab-recording"

--- a/client/DirectionsPanel.jsx
+++ b/client/DirectionsPanel.jsx
@@ -273,7 +273,7 @@ export function DirectionsPanel() {
           aria-labelledby="script-tab-blueprint"
           hidden={activeTab !== 'blueprint'}
         >
-          <BlueprintPanel embedded />
+          <BlueprintPanel />
         </div>
 
         <div

--- a/client/DirectionsPanel.jsx
+++ b/client/DirectionsPanel.jsx
@@ -283,7 +283,7 @@ export function DirectionsPanel() {
           aria-labelledby="script-tab-recording"
           hidden={activeTab !== 'recording'}
         >
-          <RecordingSettingsPanel embedded />
+          <RecordingSettingsPanel />
         </div>
       </div>
 

--- a/client/DirectionsPanel.jsx
+++ b/client/DirectionsPanel.jsx
@@ -143,15 +143,6 @@ export function DirectionsPanel() {
             Recording Settings
           </button>
         </div>
-        {activeTab === 'directions' && hasDirections && (
-          <button
-            className="view-toggle-btn"
-            type="button"
-            onClick={() => setDirectionsView(directionsView === 'actions' ? 'json' : 'actions')}
-          >
-            {directionsView === 'actions' ? 'Show JSON' : 'Show Actions'}
-          </button>
-        )}
       </div>
 
       <div className="script-settings-scroll">
@@ -162,6 +153,27 @@ export function DirectionsPanel() {
           aria-labelledby="script-tab-directions"
           hidden={activeTab !== 'directions'}
         >
+          <div className="directions-view-switcher">
+            <div className="directions-view-toggle" role="group" aria-label="Directions view">
+              <button
+                className={`directions-view-toggle-btn${directionsView === 'actions' ? ' active' : ''}`}
+                type="button"
+                aria-pressed={directionsView === 'actions'}
+                onClick={() => setDirectionsView('actions')}
+              >
+                Actions
+              </button>
+              <button
+                className={`directions-view-toggle-btn${directionsView === 'json' ? ' active' : ''}`}
+                type="button"
+                aria-pressed={directionsView === 'json'}
+                onClick={() => setDirectionsView('json')}
+              >
+                JSON
+              </button>
+            </div>
+          </div>
+
           {directionsView === 'actions' && (
             <>
               <ul id="step-list">
@@ -232,7 +244,7 @@ export function DirectionsPanel() {
 
               {!hasDirections && <p id="empty-hint" className="hint">Type a command above, or insert a direction below.</p>}
 
-              <div id="direction-insert-bottom">
+              <div id="direction-insert-bottom" className="directions-tab-actions">
                 <button
                   className="direction-insert-plus direction-insert-plus--bottom"
                   title="Insert direction"

--- a/client/DirectionsPanel.jsx
+++ b/client/DirectionsPanel.jsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useCallback, useRef, useState } from 'react';
 import { toast } from 'react-toastify';
 import { useAppState } from './context/AppStateContext.jsx';
@@ -110,7 +111,7 @@ export function DirectionsPanel() {
         <div className="script-settings-tabs" role="tablist" aria-label="Script settings">
           <button
             id="script-tab-directions"
-            className={`script-settings-tab${activeTab === 'directions' ? ' active' : ''}`}
+            className={clsx('script-settings-tab', activeTab === 'directions' && 'active')}
             type="button"
             role="tab"
             aria-selected={activeTab === 'directions'}
@@ -121,7 +122,7 @@ export function DirectionsPanel() {
           </button>
           <button
             id="script-tab-blueprint"
-            className={`script-settings-tab${activeTab === 'blueprint' ? ' active' : ''}`}
+            className={clsx('script-settings-tab', activeTab === 'blueprint' && 'active')}
             type="button"
             role="tab"
             aria-selected={activeTab === 'blueprint'}
@@ -129,11 +130,11 @@ export function DirectionsPanel() {
             onClick={() => selectTab('blueprint')}
           >
             Blueprint
-            <PoolStatusIndicators className="blueprint-pool-indicators--tab" />
+            <PoolStatusIndicators tab />
           </button>
           <button
             id="script-tab-recording"
-            className={`script-settings-tab${activeTab === 'recording' ? ' active' : ''}`}
+            className={clsx('script-settings-tab', activeTab === 'recording' && 'active')}
             type="button"
             role="tab"
             aria-selected={activeTab === 'recording'}
@@ -156,7 +157,7 @@ export function DirectionsPanel() {
           <div className="directions-view-switcher">
             <div className="directions-view-toggle" role="group" aria-label="Directions view">
               <button
-                className={`directions-view-toggle-btn${directionsView === 'actions' ? ' active' : ''}`}
+                className={clsx('directions-view-toggle-btn', directionsView === 'actions' && 'active')}
                 type="button"
                 aria-pressed={directionsView === 'actions'}
                 onClick={() => setDirectionsView('actions')}
@@ -164,7 +165,7 @@ export function DirectionsPanel() {
                 Actions
               </button>
               <button
-                className={`directions-view-toggle-btn${directionsView === 'json' ? ' active' : ''}`}
+                className={clsx('directions-view-toggle-btn', directionsView === 'json' && 'active')}
                 type="button"
                 aria-pressed={directionsView === 'json'}
                 onClick={() => setDirectionsView('json')}

--- a/client/Layout.jsx
+++ b/client/Layout.jsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useEffect, useState } from 'react';
 import { CommandBar } from './CommandBar.jsx';
 import { DirectionToolbar } from './DirectionToolbar.jsx';
@@ -36,7 +37,7 @@ export function Layout() {
         &#9776;
       </button>
 
-      <div className={`main-content${sidebarOpen ? ' sidebar-open' : ''}`}>
+      <div className={clsx('main-content', sidebarOpen && 'sidebar-open')}>
         <CommandBar />
         <DirectionToolbar />
         <div className="workspace">

--- a/client/PoolStatusIndicators.jsx
+++ b/client/PoolStatusIndicators.jsx
@@ -1,0 +1,96 @@
+import { useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useAppState } from './context/AppStateContext.jsx';
+
+const SLOT_STATUS_LABELS = {
+  active: 'In use',
+  booting: 'Loading',
+  idle: 'Idle',
+  warm: 'Ready and warm',
+};
+
+function statusLabel(status) {
+  return SLOT_STATUS_LABELS[status] ?? 'Unknown';
+}
+
+function poolSlotTitle(slot) {
+  const port = slot.port ? ` (port ${slot.port})` : '';
+  return `Playground ${slot.index + 1}${port}: ${statusLabel(slot.status)}`;
+}
+
+function poolSlotClass(status) {
+  return SLOT_STATUS_LABELS[status] ? status : 'unknown';
+}
+
+function inferredPoolSlots(poolStatus = {}) {
+  if (Array.isArray(poolStatus.slots) && poolStatus.slots.length > 0) {
+    return poolStatus.slots;
+  }
+
+  const total = Number(poolStatus.total) || 0;
+  const warm = Number(poolStatus.warm) || 0;
+  const booting = Number(poolStatus.booting) || 0;
+
+  return Array.from({ length: total }, (_, index) => ({
+    index,
+    port: null,
+    status: index < warm ? 'warm' : index < warm + booting ? 'booting' : 'idle',
+  }));
+}
+
+export function PoolStatusIndicators({ className = '' } = {}) {
+  const { poolStatus } = useAppState();
+  const [poolTooltip, setPoolTooltip] = useState(null);
+  const poolSlots = useMemo(() => inferredPoolSlots(poolStatus ?? {}), [poolStatus]);
+
+  function showPoolTooltip(text, target) {
+    const rect = target.getBoundingClientRect();
+    const minX = 140;
+    const maxX = Math.max(minX, window.innerWidth - minX);
+    const centerX = rect.left + rect.width / 2;
+    setPoolTooltip({
+      text,
+      left: Math.min(Math.max(centerX, minX), maxX),
+      top: rect.top - 8,
+    });
+  }
+
+  function hidePoolTooltip() {
+    setPoolTooltip(null);
+  }
+
+  if (poolSlots.length === 0) return null;
+
+  return (
+    <>
+      <span className={`blueprint-pool-indicators${className ? ` ${className}` : ''}`} aria-label="Playground pool status">
+        {poolSlots.map((slot) => {
+          const title = poolSlotTitle(slot);
+          return (
+            <span
+              key={slot.port ?? slot.index}
+              className={`blueprint-pool-indicator blueprint-pool-indicator--${poolSlotClass(slot.status)}`}
+              aria-label={title}
+              role="img"
+              onMouseEnter={(event) => showPoolTooltip(title, event.currentTarget)}
+              onMouseLeave={hidePoolTooltip}
+            />
+          );
+        })}
+      </span>
+      {poolTooltip && createPortal(
+        <div
+          className="blueprint-pool-tooltip"
+          role="tooltip"
+          style={{
+            left: `${poolTooltip.left}px`,
+            top: `${poolTooltip.top}px`,
+          }}
+        >
+          {poolTooltip.text}
+        </div>,
+        document.body,
+      )}
+    </>
+  );
+}

--- a/client/PoolStatusIndicators.jsx
+++ b/client/PoolStatusIndicators.jsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useAppState } from './context/AppStateContext.jsx';
@@ -9,6 +10,14 @@ const SLOT_STATUS_LABELS = {
   warm: 'Ready and warm',
 };
 
+const SLOT_STATUS_CLASS_NAMES = {
+  active: 'blueprint-pool-indicator blueprint-pool-indicator--active',
+  booting: 'blueprint-pool-indicator blueprint-pool-indicator--booting',
+  idle: 'blueprint-pool-indicator blueprint-pool-indicator--idle',
+  warm: 'blueprint-pool-indicator blueprint-pool-indicator--warm',
+  unknown: 'blueprint-pool-indicator blueprint-pool-indicator--unknown',
+};
+
 function statusLabel(status) {
   return SLOT_STATUS_LABELS[status] ?? 'Unknown';
 }
@@ -18,8 +27,8 @@ function poolSlotTitle(slot) {
   return `Playground ${slot.index + 1}${port}: ${statusLabel(slot.status)}`;
 }
 
-function poolSlotClass(status) {
-  return SLOT_STATUS_LABELS[status] ? status : 'unknown';
+function poolSlotClassName(status) {
+  return SLOT_STATUS_CLASS_NAMES[status] ?? SLOT_STATUS_CLASS_NAMES.unknown;
 }
 
 function inferredPoolSlots(poolStatus = {}) {
@@ -38,7 +47,7 @@ function inferredPoolSlots(poolStatus = {}) {
   }));
 }
 
-export function PoolStatusIndicators({ className = '' } = {}) {
+export function PoolStatusIndicators({ tab = false } = {}) {
   const { poolStatus } = useAppState();
   const [poolTooltip, setPoolTooltip] = useState(null);
   const poolSlots = useMemo(() => inferredPoolSlots(poolStatus ?? {}), [poolStatus]);
@@ -63,13 +72,13 @@ export function PoolStatusIndicators({ className = '' } = {}) {
 
   return (
     <>
-      <span className={`blueprint-pool-indicators${className ? ` ${className}` : ''}`} aria-label="Playground pool status">
+      <span className={clsx('blueprint-pool-indicators', tab && 'blueprint-pool-indicators--tab')} aria-label="Playground pool status">
         {poolSlots.map((slot) => {
           const title = poolSlotTitle(slot);
           return (
             <span
               key={slot.port ?? slot.index}
-              className={`blueprint-pool-indicator blueprint-pool-indicator--${poolSlotClass(slot.status)}`}
+              className={poolSlotClassName(slot.status)}
               aria-label={title}
               role="img"
               onMouseEnter={(event) => showPoolTooltip(title, event.currentTarget)}

--- a/client/PreviewPanel.jsx
+++ b/client/PreviewPanel.jsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useRunState } from './context/RunContext.jsx';
 import { formatTimestamp } from './utils/formatters.js';
 
@@ -13,7 +14,7 @@ export function PreviewPanel() {
     : null;
 
   return (
-    <div className={`panel${isPolling ? ' polling' : ''}`} id="preview-panel">
+    <div className={clsx('panel', isPolling && 'polling')} id="preview-panel">
       <div className="preview-heading">
         <h2>{heading}</h2>
         {recordingTimestamp && <span className="preview-heading-timestamp">{recordingTimestamp}</span>}

--- a/client/Sidebar.jsx
+++ b/client/Sidebar.jsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { DirectionLibraryPanel } from './Sidebar/DirectionLibraryPanel.jsx';
 import { LogPanel } from './Sidebar/LogPanel.jsx';
 import { RecordingsPanel } from './Sidebar/RecordingsPanel.jsx';
@@ -5,7 +6,7 @@ import { SavedScriptsPanel } from './Sidebar/SavedScriptsPanel.jsx';
 
 export function Sidebar({ open, style }) {
   return (
-    <div id="right-sidebar" className={`right-sidebar${open ? ' open' : ''}`} aria-label="Tools sidebar" style={style}>
+    <div id="right-sidebar" className={clsx('right-sidebar', open && 'open')} aria-label="Tools sidebar" style={style}>
       <div className="sidebar-content">
         <SavedScriptsPanel />
         <DirectionLibraryPanel />

--- a/client/Sidebar.jsx
+++ b/client/Sidebar.jsx
@@ -1,7 +1,5 @@
-import { BlueprintPanel } from './Sidebar/BlueprintPanel.jsx';
 import { DirectionLibraryPanel } from './Sidebar/DirectionLibraryPanel.jsx';
 import { LogPanel } from './Sidebar/LogPanel.jsx';
-import { RecordingSettingsPanel } from './Sidebar/RecordingSettingsPanel.jsx';
 import { RecordingsPanel } from './Sidebar/RecordingsPanel.jsx';
 import { SavedScriptsPanel } from './Sidebar/SavedScriptsPanel.jsx';
 
@@ -12,8 +10,6 @@ export function Sidebar({ open, style }) {
         <SavedScriptsPanel />
         <DirectionLibraryPanel />
         <RecordingsPanel />
-        <BlueprintPanel />
-        <RecordingSettingsPanel />
         <LogPanel />
       </div>
     </div>

--- a/client/Sidebar/BlueprintPanel.jsx
+++ b/client/Sidebar/BlueprintPanel.jsx
@@ -8,10 +8,9 @@ import { EnvironmentSection } from '../blueprint/EnvironmentSection.jsx';
 import { SiteSettingsSection } from '../blueprint/SiteSettingsSection.jsx';
 import { SlugListSection } from '../blueprint/SlugListSection.jsx';
 import { ContentSection } from '../blueprint/ContentSection.jsx';
-import { SectionBadge } from './SectionBadge.jsx';
 
-export function BlueprintPanel({ embedded = false } = {}) {
-  const { blueprint: appBlueprint, defaultBlueprint, setBlueprint, isBlueprintModified } = useAppState();
+export function BlueprintPanel() {
+  const { blueprint: appBlueprint, defaultBlueprint, setBlueprint } = useAppState();
   const { formState, updateForm, loadBlueprint, compiledBlueprint } =
     useBlueprintFormState(appBlueprint);
 
@@ -58,8 +57,8 @@ export function BlueprintPanel({ embedded = false } = {}) {
     }
   }
 
-  const content = (
-    <div className={`blueprint-body${embedded ? ' blueprint-body--embedded' : ''}`}>
+  return (
+    <div className="blueprint-body blueprint-body--embedded">
       <EnvironmentSection formState={formState} updateForm={updateForm} />
       <SiteSettingsSection formState={formState} updateForm={updateForm} />
       <SlugListSection
@@ -104,17 +103,5 @@ export function BlueprintPanel({ embedded = false } = {}) {
         </button>
       </div>
     </div>
-  );
-
-  if (embedded) return content;
-
-  return (
-    <details id="blueprint-section">
-      <summary>
-        <span>Environment / Blueprint</span>
-        <SectionBadge hidden={!isBlueprintModified}>custom</SectionBadge>
-      </summary>
-      {content}
-    </details>
   );
 }

--- a/client/Sidebar/BlueprintPanel.jsx
+++ b/client/Sidebar/BlueprintPanel.jsx
@@ -14,37 +14,37 @@ export function BlueprintPanel() {
   const { formState, updateForm, loadBlueprint, compiledBlueprint } =
     useBlueprintFormState(appBlueprint);
 
-  const [isSaving, setIsSaving] = useState(false);
+  const [isApplying, setIsApplying] = useState(false);
 
   // Compare on form-state (not compiled JSON) so incidental key-order / shape
   // differences in the on-disk blueprint don't make the form look "dirty".
-  const savedForm = useMemo(() => blueprintToForm(appBlueprint), [appBlueprint]);
+  const appliedForm = useMemo(() => blueprintToForm(appBlueprint), [appBlueprint]);
   const defaultForm = useMemo(() => blueprintToForm(defaultBlueprint), [defaultBlueprint]);
-  const hasUnsavedChanges = useMemo(
-    () => JSON.stringify(formState) !== JSON.stringify(savedForm),
-    [formState, savedForm],
+  const hasUnappliedChanges = useMemo(
+    () => JSON.stringify(formState) !== JSON.stringify(appliedForm),
+    [formState, appliedForm],
   );
   const isAtDefault = useMemo(
     () => JSON.stringify(formState) === JSON.stringify(defaultForm),
     [formState, defaultForm],
   );
 
-  async function handleSave() {
-    setIsSaving(true);
+  async function handleApply() {
+    setIsApplying(true);
     try {
       await api.saveBlueprint(compiledBlueprint);
       setBlueprint(compiledBlueprint);
     } catch (err) {
-      toast.error(errorMessage(err, 'Could not save blueprint'));
+      toast.error(errorMessage(err, 'Could not apply blueprint'));
     } finally {
-      setIsSaving(false);
+      setIsApplying(false);
     }
   }
 
   async function handleReset() {
     if (!defaultBlueprint) return;
     if (!window.confirm('Reset all fields to the default blueprint? Your current changes will be lost.')) return;
-    setIsSaving(true);
+    setIsApplying(true);
     try {
       const bp = await api.resetBlueprint();
       const target = bp ?? defaultBlueprint;
@@ -53,7 +53,7 @@ export function BlueprintPanel() {
     } catch (err) {
       toast.error(errorMessage(err, 'Could not reset blueprint'));
     } finally {
-      setIsSaving(false);
+      setIsApplying(false);
     }
   }
 
@@ -89,17 +89,17 @@ export function BlueprintPanel() {
           type="button"
           className="bp-action-btn bp-action-btn--ghost"
           onClick={handleReset}
-          disabled={!defaultBlueprint || isAtDefault || isSaving}
+          disabled={!defaultBlueprint || isAtDefault || isApplying}
         >
           Reset
         </button>
         <button
           type="button"
-          className="bp-action-btn bp-action-btn--primary"
-          onClick={handleSave}
-          disabled={isSaving || !hasUnsavedChanges}
+          className={`bp-action-btn bp-action-btn--primary${isApplying ? ' is-loading' : ''}`}
+          onClick={handleApply}
+          disabled={isApplying || !hasUnappliedChanges}
         >
-          {isSaving ? 'Saving…' : 'Save'}
+          Apply
         </button>
       </div>
     </div>

--- a/client/Sidebar/BlueprintPanel.jsx
+++ b/client/Sidebar/BlueprintPanel.jsx
@@ -1,5 +1,4 @@
 import { useState, useMemo } from 'react';
-import { createPortal } from 'react-dom';
 import { toast } from 'react-toastify';
 import { useAppState } from '../context/AppStateContext.jsx';
 import { blueprintToForm, useBlueprintFormState } from '../state/useBlueprintFormState.js';
@@ -11,49 +10,12 @@ import { SlugListSection } from '../blueprint/SlugListSection.jsx';
 import { ContentSection } from '../blueprint/ContentSection.jsx';
 import { SectionBadge } from './SectionBadge.jsx';
 
-const SLOT_STATUS_LABELS = {
-  active: 'In use',
-  booting: 'Loading',
-  idle: 'Idle',
-  warm: 'Ready and warm',
-};
-
-function statusLabel(status) {
-  return SLOT_STATUS_LABELS[status] ?? 'Unknown';
-}
-
-function poolSlotTitle(slot) {
-  const port = slot.port ? ` (port ${slot.port})` : '';
-  return `Playground ${slot.index + 1}${port}: ${statusLabel(slot.status)}`;
-}
-
-function poolSlotClass(status) {
-  return SLOT_STATUS_LABELS[status] ? status : 'unknown';
-}
-
-function inferredPoolSlots(poolStatus) {
-  if (Array.isArray(poolStatus.slots) && poolStatus.slots.length > 0) {
-    return poolStatus.slots;
-  }
-
-  const total = Number(poolStatus.total) || 0;
-  const warm = Number(poolStatus.warm) || 0;
-  const booting = Number(poolStatus.booting) || 0;
-
-  return Array.from({ length: total }, (_, index) => ({
-    index,
-    port: null,
-    status: index < warm ? 'warm' : index < warm + booting ? 'booting' : 'idle',
-  }));
-}
-
 export function BlueprintPanel({ embedded = false } = {}) {
-  const { blueprint: appBlueprint, defaultBlueprint, setBlueprint, isBlueprintModified, poolStatus } = useAppState();
+  const { blueprint: appBlueprint, defaultBlueprint, setBlueprint, isBlueprintModified } = useAppState();
   const { formState, updateForm, loadBlueprint, compiledBlueprint } =
     useBlueprintFormState(appBlueprint);
 
   const [isSaving, setIsSaving] = useState(false);
-  const [poolTooltip, setPoolTooltip] = useState(null);
 
   // Compare on form-state (not compiled JSON) so incidental key-order / shape
   // differences in the on-disk blueprint don't make the form look "dirty".
@@ -67,7 +29,6 @@ export function BlueprintPanel({ embedded = false } = {}) {
     () => JSON.stringify(formState) === JSON.stringify(defaultForm),
     [formState, defaultForm],
   );
-  const poolSlots = useMemo(() => inferredPoolSlots(poolStatus), [poolStatus]);
 
   async function handleSave() {
     setIsSaving(true);
@@ -95,22 +56,6 @@ export function BlueprintPanel({ embedded = false } = {}) {
     } finally {
       setIsSaving(false);
     }
-  }
-
-  function showPoolTooltip(text, target) {
-    const rect = target.getBoundingClientRect();
-    const minX = 140;
-    const maxX = Math.max(minX, window.innerWidth - minX);
-    const centerX = rect.left + rect.width / 2;
-    setPoolTooltip({
-      text,
-      left: Math.min(Math.max(centerX, minX), maxX),
-      top: rect.top - 8,
-    });
-  }
-
-  function hidePoolTooltip() {
-    setPoolTooltip(null);
   }
 
   const content = (
@@ -141,26 +86,6 @@ export function BlueprintPanel({ embedded = false } = {}) {
       </section>
 
       <div className="blueprint-panel-actions">
-        {poolSlots.length > 0 && (
-          <div className="blueprint-pool-indicators" aria-label="Playground pool status">
-            {poolSlots.map((slot) => {
-              const title = poolSlotTitle(slot);
-              return (
-                <span
-                  key={slot.port ?? slot.index}
-                  className={`blueprint-pool-indicator blueprint-pool-indicator--${poolSlotClass(slot.status)}`}
-                  aria-label={title}
-                  role="img"
-                  tabIndex={0}
-                  onBlur={hidePoolTooltip}
-                  onFocus={(event) => showPoolTooltip(title, event.currentTarget)}
-                  onMouseEnter={(event) => showPoolTooltip(title, event.currentTarget)}
-                  onMouseLeave={hidePoolTooltip}
-                />
-              );
-            })}
-          </div>
-        )}
         <button
           type="button"
           className="bp-action-btn bp-action-btn--ghost"
@@ -178,19 +103,6 @@ export function BlueprintPanel({ embedded = false } = {}) {
           {isSaving ? 'Saving…' : 'Save'}
         </button>
       </div>
-      {poolTooltip && createPortal(
-        <div
-          className="blueprint-pool-tooltip"
-          role="tooltip"
-          style={{
-            left: `${poolTooltip.left}px`,
-            top: `${poolTooltip.top}px`,
-          }}
-        >
-          {poolTooltip.text}
-        </div>,
-        document.body,
-      )}
     </div>
   );
 

--- a/client/Sidebar/BlueprintPanel.jsx
+++ b/client/Sidebar/BlueprintPanel.jsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useState, useMemo } from 'react';
 import { toast } from 'react-toastify';
 import { useAppState } from '../context/AppStateContext.jsx';
@@ -95,7 +96,7 @@ export function BlueprintPanel() {
         </button>
         <button
           type="button"
-          className={`bp-action-btn bp-action-btn--primary${isApplying ? ' is-loading' : ''}`}
+          className={clsx('bp-action-btn bp-action-btn--primary', isApplying && 'is-loading')}
           onClick={handleApply}
           disabled={isApplying || !hasUnappliedChanges}
         >

--- a/client/Sidebar/BlueprintPanel.jsx
+++ b/client/Sidebar/BlueprintPanel.jsx
@@ -47,7 +47,7 @@ function inferredPoolSlots(poolStatus) {
   }));
 }
 
-export function BlueprintPanel() {
+export function BlueprintPanel({ embedded = false } = {}) {
   const { blueprint: appBlueprint, defaultBlueprint, setBlueprint, isBlueprintModified, poolStatus } = useAppState();
   const { formState, updateForm, loadBlueprint, compiledBlueprint } =
     useBlueprintFormState(appBlueprint);
@@ -113,90 +113,96 @@ export function BlueprintPanel() {
     setPoolTooltip(null);
   }
 
+  const content = (
+    <div className={`blueprint-body${embedded ? ' blueprint-body--embedded' : ''}`}>
+      <EnvironmentSection formState={formState} updateForm={updateForm} />
+      <SiteSettingsSection formState={formState} updateForm={updateForm} />
+      <SlugListSection
+        title="Plugins" sectionId="section-plugins"
+        items={formState.plugins} onUpdate={(plugins) => updateForm({ plugins })}
+        itemType="plugin" inputId="bf-plugin-slug"
+        inputPlaceholder="WordPress.org plugin slug"
+      />
+      <SlugListSection
+        title="Themes" sectionId="section-themes"
+        items={formState.themes} onUpdate={(themes) => updateForm({ themes })}
+        itemType="theme" inputId="bf-theme-slug"
+        inputPlaceholder="WordPress.org theme slug"
+      />
+      <ContentSection formState={formState} updateForm={updateForm} />
+
+      <section className="blueprint-form-section">
+        <details className="bfs-collapsible">
+          <summary className="bfs-summary">JSON</summary>
+          <pre className="bfs-json-preview">
+            {JSON.stringify(compiledBlueprint, null, 2)}
+          </pre>
+        </details>
+      </section>
+
+      <div className="blueprint-panel-actions">
+        {poolSlots.length > 0 && (
+          <div className="blueprint-pool-indicators" aria-label="Playground pool status">
+            {poolSlots.map((slot) => {
+              const title = poolSlotTitle(slot);
+              return (
+                <span
+                  key={slot.port ?? slot.index}
+                  className={`blueprint-pool-indicator blueprint-pool-indicator--${poolSlotClass(slot.status)}`}
+                  aria-label={title}
+                  role="img"
+                  tabIndex={0}
+                  onBlur={hidePoolTooltip}
+                  onFocus={(event) => showPoolTooltip(title, event.currentTarget)}
+                  onMouseEnter={(event) => showPoolTooltip(title, event.currentTarget)}
+                  onMouseLeave={hidePoolTooltip}
+                />
+              );
+            })}
+          </div>
+        )}
+        <button
+          type="button"
+          className="bp-action-btn bp-action-btn--ghost"
+          onClick={handleReset}
+          disabled={!defaultBlueprint || isAtDefault || isSaving}
+        >
+          Reset
+        </button>
+        <button
+          type="button"
+          className="bp-action-btn bp-action-btn--primary"
+          onClick={handleSave}
+          disabled={isSaving || !hasUnsavedChanges}
+        >
+          {isSaving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+      {poolTooltip && createPortal(
+        <div
+          className="blueprint-pool-tooltip"
+          role="tooltip"
+          style={{
+            left: `${poolTooltip.left}px`,
+            top: `${poolTooltip.top}px`,
+          }}
+        >
+          {poolTooltip.text}
+        </div>,
+        document.body,
+      )}
+    </div>
+  );
+
+  if (embedded) return content;
+
   return (
     <details id="blueprint-section">
       <summary>
         <span>Environment / Blueprint</span>
         <SectionBadge hidden={!isBlueprintModified}>custom</SectionBadge>
       </summary>
-      <div className="blueprint-body">
-        <EnvironmentSection formState={formState} updateForm={updateForm} />
-        <SiteSettingsSection formState={formState} updateForm={updateForm} />
-        <SlugListSection
-          title="Plugins" sectionId="section-plugins"
-          items={formState.plugins} onUpdate={(plugins) => updateForm({ plugins })}
-          itemType="plugin" inputId="bf-plugin-slug"
-          inputPlaceholder="WordPress.org plugin slug"
-        />
-        <SlugListSection
-          title="Themes" sectionId="section-themes"
-          items={formState.themes} onUpdate={(themes) => updateForm({ themes })}
-          itemType="theme" inputId="bf-theme-slug"
-          inputPlaceholder="WordPress.org theme slug"
-        />
-        <ContentSection formState={formState} updateForm={updateForm} />
-
-        <section className="blueprint-form-section">
-          <details className="bfs-collapsible">
-            <summary className="bfs-summary">JSON</summary>
-            <pre className="bfs-json-preview">
-              {JSON.stringify(compiledBlueprint, null, 2)}
-            </pre>
-          </details>
-        </section>
-
-        <div className="blueprint-panel-actions">
-          {poolSlots.length > 0 && (
-            <div className="blueprint-pool-indicators" aria-label="Playground pool status">
-              {poolSlots.map((slot) => {
-                const title = poolSlotTitle(slot);
-                return (
-                  <span
-                    key={slot.port ?? slot.index}
-                    className={`blueprint-pool-indicator blueprint-pool-indicator--${poolSlotClass(slot.status)}`}
-                    aria-label={title}
-                    role="img"
-                    tabIndex={0}
-                    onBlur={hidePoolTooltip}
-                    onFocus={(event) => showPoolTooltip(title, event.currentTarget)}
-                    onMouseEnter={(event) => showPoolTooltip(title, event.currentTarget)}
-                    onMouseLeave={hidePoolTooltip}
-                  />
-                );
-              })}
-            </div>
-          )}
-          <button
-            type="button"
-            className="bp-action-btn bp-action-btn--ghost"
-            onClick={handleReset}
-            disabled={!defaultBlueprint || isAtDefault || isSaving}
-          >
-            Reset
-          </button>
-          <button
-            type="button"
-            className="bp-action-btn bp-action-btn--primary"
-            onClick={handleSave}
-            disabled={isSaving || !hasUnsavedChanges}
-          >
-            {isSaving ? 'Saving…' : 'Save'}
-          </button>
-        </div>
-        {poolTooltip && createPortal(
-          <div
-            className="blueprint-pool-tooltip"
-            role="tooltip"
-            style={{
-              left: `${poolTooltip.left}px`,
-              top: `${poolTooltip.top}px`,
-            }}
-          >
-            {poolTooltip.text}
-          </div>,
-          document.body,
-        )}
-      </div>
+      {content}
     </details>
   );
 }

--- a/client/Sidebar/DirectionLibraryPanel.jsx
+++ b/client/Sidebar/DirectionLibraryPanel.jsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { toast } from 'react-toastify';
 import { useAppState } from '../context/AppStateContext.jsx';
 import { errorMessage } from '../utils/actions.js';
@@ -28,7 +29,7 @@ export function DirectionLibraryPanel() {
           {!libraryEntries.length && <p className="hint">No directions yet.</p>}
 
           {libraryEntries.map((entry) => (
-            <div className={`direction-item${entry.builtin ? ' direction-item--builtin' : ''}`} key={entry.filename}>
+            <div className={clsx('direction-item', entry.builtin && 'direction-item--builtin')} key={entry.filename}>
               <span className="direction-name">{entry.name}</span>
               <span className="direction-meta">
                 {entry.directionCount} step{entry.directionCount !== 1 ? 's' : ''}

--- a/client/Sidebar/RecordingSettingsPanel.jsx
+++ b/client/Sidebar/RecordingSettingsPanel.jsx
@@ -7,7 +7,7 @@ const VIDEO_LABELS = {
   '3840x2160': '4K',
 };
 
-export function RecordingSettingsPanel({ embedded = false } = {}) {
+export function RecordingSettingsPanel() {
   const {
     endPause,
     setEndPause,
@@ -19,8 +19,8 @@ export function RecordingSettingsPanel({ embedded = false } = {}) {
     videoSize,
   } = useAppState();
 
-  const content = (
-    <div className={`recording-settings-body${embedded ? ' recording-settings-body--embedded' : ''}`}>
+  return (
+    <div className="recording-settings-body recording-settings-body--embedded">
       <div className="setting-field">
         <div className="setting-field-header">
           <label htmlFor="typing-delay-input">Typing speed</label>
@@ -91,16 +91,5 @@ export function RecordingSettingsPanel({ embedded = false } = {}) {
         />
       </div>
     </div>
-  );
-
-  if (embedded) return content;
-
-  return (
-    <details id="recording-settings-section">
-      <summary>
-        <span>Recording Settings</span>
-      </summary>
-      {content}
-    </details>
   );
 }

--- a/client/Sidebar/RecordingSettingsPanel.jsx
+++ b/client/Sidebar/RecordingSettingsPanel.jsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useAppState } from '../context/AppStateContext.jsx';
 import { VIDEO_SIZE_VALUES } from '../utils/actions.js';
 
@@ -63,7 +64,7 @@ export function RecordingSettingsPanel() {
             <button
               key={size}
               type="button"
-              className={`settings-size-opt${videoSize === size ? ' active' : ''}`}
+              className={clsx('settings-size-opt', videoSize === size && 'active')}
               role="radio"
               aria-checked={videoSize === size}
               title={`${VIDEO_LABELS[size]} (${size})`}

--- a/client/Sidebar/RecordingSettingsPanel.jsx
+++ b/client/Sidebar/RecordingSettingsPanel.jsx
@@ -7,7 +7,7 @@ const VIDEO_LABELS = {
   '3840x2160': '4K',
 };
 
-export function RecordingSettingsPanel() {
+export function RecordingSettingsPanel({ embedded = false } = {}) {
   const {
     endPause,
     setEndPause,
@@ -19,82 +19,88 @@ export function RecordingSettingsPanel() {
     videoSize,
   } = useAppState();
 
+  const content = (
+    <div className={`recording-settings-body${embedded ? ' recording-settings-body--embedded' : ''}`}>
+      <div className="setting-field">
+        <div className="setting-field-header">
+          <label htmlFor="typing-delay-input">Typing speed</label>
+          <span className="setting-field-value">{typingDelay} ms/char</span>
+        </div>
+        <input
+          id="typing-delay-input"
+          type="range"
+          min="0"
+          max="250"
+          step="10"
+          value={typingDelay}
+          onChange={(event) => setTypingDelay(event.target.value)}
+        />
+      </div>
+
+      <div className="setting-field">
+        <div className="setting-field-header">
+          <label htmlFor="step-pause-input">Between-step pause</label>
+          <span className="setting-field-value">{stepPause}s</span>
+        </div>
+        <input
+          id="step-pause-input"
+          type="range"
+          min="0"
+          max="3"
+          step="0.1"
+          value={stepPause}
+          onChange={(event) => setStepPause(event.target.value)}
+        />
+      </div>
+
+      <div className="setting-field">
+        <div className="setting-field-header">
+          <span className="setting-field-label">Video size</span>
+          <span className="setting-field-value">{videoSize}</span>
+        </div>
+        <div className="settings-size-toggle" role="radiogroup" aria-label="Video size">
+          {VIDEO_SIZE_VALUES.map((size) => (
+            <button
+              key={size}
+              type="button"
+              className={`settings-size-opt${videoSize === size ? ' active' : ''}`}
+              role="radio"
+              aria-checked={videoSize === size}
+              title={`${VIDEO_LABELS[size]} (${size})`}
+              onClick={() => setVideoSize(size)}
+            >
+              {VIDEO_LABELS[size]}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="setting-field">
+        <div className="setting-field-header">
+          <label htmlFor="end-pause-input">Outro length</label>
+          <span className="setting-field-value">{endPause}s</span>
+        </div>
+        <input
+          id="end-pause-input"
+          type="range"
+          min="0"
+          max="10"
+          step="0.5"
+          value={endPause}
+          onChange={(event) => setEndPause(event.target.value)}
+        />
+      </div>
+    </div>
+  );
+
+  if (embedded) return content;
+
   return (
     <details id="recording-settings-section">
       <summary>
         <span>Recording Settings</span>
       </summary>
-      <div className="recording-settings-body">
-        <div className="setting-field">
-          <div className="setting-field-header">
-            <label htmlFor="typing-delay-input">Typing speed</label>
-            <span className="setting-field-value">{typingDelay} ms/char</span>
-          </div>
-          <input
-            id="typing-delay-input"
-            type="range"
-            min="0"
-            max="250"
-            step="10"
-            value={typingDelay}
-            onChange={(event) => setTypingDelay(event.target.value)}
-          />
-        </div>
-
-        <div className="setting-field">
-          <div className="setting-field-header">
-            <label htmlFor="step-pause-input">Between-step pause</label>
-            <span className="setting-field-value">{stepPause}s</span>
-          </div>
-          <input
-            id="step-pause-input"
-            type="range"
-            min="0"
-            max="3"
-            step="0.1"
-            value={stepPause}
-            onChange={(event) => setStepPause(event.target.value)}
-          />
-        </div>
-
-        <div className="setting-field">
-          <div className="setting-field-header">
-            <span className="setting-field-label">Video size</span>
-            <span className="setting-field-value">{videoSize}</span>
-          </div>
-          <div className="settings-size-toggle" role="radiogroup" aria-label="Video size">
-            {VIDEO_SIZE_VALUES.map((size) => (
-              <button
-                key={size}
-                type="button"
-                className={`settings-size-opt${videoSize === size ? ' active' : ''}`}
-                role="radio"
-                aria-checked={videoSize === size}
-                title={`${VIDEO_LABELS[size]} (${size})`}
-                onClick={() => setVideoSize(size)}
-              >
-                {VIDEO_LABELS[size]}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        <div className="setting-field">
-          <div className="setting-field-header">
-            <label htmlFor="end-pause-input">Outro length</label>
-            <span className="setting-field-value">{endPause}s</span>
-          </div>
-          <input
-            id="end-pause-input"
-            type="range"
-            min="0"
-            max="10"
-            step="0.5"
-            value={endPause}
-            onChange={(event) => setEndPause(event.target.value)}
-          />
-        </div>
-      </div>
+      {content}
     </details>
   );
 }

--- a/client/Sidebar/SectionBadge.jsx
+++ b/client/Sidebar/SectionBadge.jsx
@@ -1,6 +1,8 @@
-export function SectionBadge({ children, hidden = false, className = '' }) {
+import clsx from 'clsx';
+
+export function SectionBadge({ children, hidden = false }) {
   return (
-    <span className={`badge${className ? ` ${className}` : ''}${hidden ? ' hidden' : ''}`}>
+    <span className={clsx('badge', hidden && 'hidden')}>
       {children}
     </span>
   );

--- a/client/blueprint/SlugListSection.jsx
+++ b/client/blueprint/SlugListSection.jsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useState } from 'react';
 
 export function SlugListSection({ title, sectionId, items, onUpdate, itemType, inputId, inputPlaceholder }) {
@@ -31,7 +32,7 @@ export function SlugListSection({ title, sectionId, items, onUpdate, itemType, i
           <input
             id={inputId}
             type="text"
-            className={`bf-input${isDuplicate && slugTrimmed ? ' bf-input-warn' : ''}`}
+            className={clsx('bf-input', isDuplicate && slugTrimmed && 'bf-input-warn')}
             value={slugInput}
             onChange={(e) => setSlugInput(e.target.value)}
             onKeyDown={handleKeyDown}

--- a/client/state/useBlueprintState.js
+++ b/client/state/useBlueprintState.js
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import {
   useCurrentBlueprintQuery,
   useDefaultBlueprintQuery,
@@ -15,14 +15,9 @@ export function useBlueprintState() {
     : null;
   const blueprint = blueprintOverride === undefined ? loadedBlueprint : blueprintOverride;
 
-  const isBlueprintModified = useMemo(() => (
-    !!defaultBlueprint && JSON.stringify(blueprint) !== JSON.stringify(defaultBlueprint)
-  ), [blueprint, defaultBlueprint]);
-
   return {
     blueprint,
     setBlueprint,
     defaultBlueprint,
-    isBlueprintModified,
   };
 }

--- a/client/state/useRunLog.js
+++ b/client/state/useRunLog.js
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useCallback, useState } from 'react';
 
 export function useRunLog() {
@@ -24,7 +25,7 @@ export function useRunLog() {
     setLogText((current) => `${current}\n--- Done (exit ${code}) ---\n`);
     setLogBadge({
       text: code === 0 ? 'complete' : 'failed',
-      className: `badge${code === 0 ? ' badge-pass' : ' badge-fail'}`,
+      className: clsx('badge', code === 0 ? 'badge-pass' : 'badge-fail'),
     });
   }, []);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
         "@tanstack/react-query": "^5.100.9",
+        "clsx": "^2.1.1",
         "dotenv": "^17.4.2",
         "express": "^4.18.0",
         "ffmpeg-static": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
     "@tanstack/react-query": "^5.100.9",
+    "clsx": "^2.1.1",
     "dotenv": "^17.4.2",
     "express": "^4.18.0",
     "ffmpeg-static": "^5.3.0",

--- a/public/style.css
+++ b/public/style.css
@@ -92,11 +92,14 @@ header p {
 
 .blueprint-body--embedded {
   background: #111827;
-  border: 1px solid #1e2433;
   border-radius: 6px;
+  box-shadow: inset 0 0 0 1px #1e2433;
+  display: flex;
+  flex-direction: column;
   max-width: 100%;
+  min-height: 100%;
   min-width: 0;
-  overflow: hidden;
+  overflow: clip;
 }
 
 .blueprint-panel-actions {
@@ -109,6 +112,18 @@ header p {
   padding: 0.75rem 1.25rem 0.75rem 0.75rem;
   border-top: 1px solid #1e2433;
   background: #111827;
+}
+
+.blueprint-body--embedded .blueprint-panel-actions {
+  bottom: 0;
+  box-shadow:
+    inset 1px 0 0 #1e2433,
+    inset -1px 0 0 #1e2433,
+    inset 0 -1px 0 #1e2433,
+    0 -10px 18px rgba(3, 7, 18, 0.35);
+  margin-top: auto;
+  position: sticky;
+  z-index: 6;
 }
 
 .blueprint-pool-indicators {

--- a/public/style.css
+++ b/public/style.css
@@ -171,7 +171,9 @@ header p {
   cursor: pointer;
   font-size: 0.85rem;
   font-weight: 500;
+  overflow: hidden;
   padding: 0.4rem 0.9rem;
+  position: relative;
   transition: background 0.15s, border-color 0.15s, color 0.15s;
   white-space: nowrap;
 }
@@ -197,6 +199,26 @@ header p {
 }
 
 .bp-action-btn--primary:hover:not(:disabled) { background: #4f46e5; }
+
+.bp-action-btn--primary.is-loading {
+  animation: bp-action-stripes 1.2s linear infinite;
+  background-image: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.18) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.18) 50%,
+    rgba(255, 255, 255, 0.18) 75%,
+    transparent 75%,
+    transparent
+  );
+  background-size: 48px 48px;
+}
+
+@keyframes bp-action-stripes {
+  from { background-position: 0 0; }
+  to   { background-position: 48px 0; }
+}
 
 /* ── Collapsible blueprint form sections ─────────────────── */
 

--- a/public/style.css
+++ b/public/style.css
@@ -852,21 +852,46 @@ header p {
   margin-bottom: 0.75rem;
 }
 
-.view-toggle-btn {
-  background: transparent;
+.directions-view-switcher {
+  background: #0f1117;
+  padding: 0 0 0.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+
+.directions-view-toggle {
+  background: #111827;
   border: 1px solid #2d3748;
   border-radius: 6px;
+  display: flex;
+  padding: 2px;
+  width: 100%;
+}
+
+.directions-view-toggle-btn {
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
   color: #64748b;
   cursor: pointer;
+  flex: 1 1 0;
   font-size: 0.72rem;
   font-weight: 600;
   letter-spacing: 0.05em;
   padding: 0.25rem 0.65rem;
   text-transform: uppercase;
-  transition: border-color 0.15s, color 0.15s;
+  transition: background 0.15s, color 0.15s;
 }
 
-.view-toggle-btn:hover { border-color: #6b7280; color: #94a3b8; }
+.directions-view-toggle-btn:hover {
+  color: #94a3b8;
+}
+
+.directions-view-toggle-btn.active {
+  background: #252f48;
+  color: #e2e8f0;
+}
 
 #steps-json-view {
   background: #111827;
@@ -1885,6 +1910,13 @@ header p {
 /* ── Bottom insert button ────────────────────────────────────────────────────── */
 #direction-insert-bottom {
   padding: 0.5rem 0 0.25rem;
+}
+
+.directions-tab-actions {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
 }
 
 .direction-insert-plus--bottom {

--- a/public/style.css
+++ b/public/style.css
@@ -36,41 +36,11 @@ header p {
   margin-top: 0.2rem;
 }
 
-/* ── Blueprint section ───────────────────────────────────── */
-
-#blueprint-section {
-  border-bottom: 1px solid #1e2433;
-}
-
 /* Sidebar sections share a common summary style */
 .sidebar-content > details {
   border-bottom: 1px solid #1e2433;
   flex: 0 0 auto;
 }
-
-#blueprint-section summary {
-  align-items: center;
-  cursor: pointer;
-  display: flex;
-  gap: 0.6rem;
-  font-size: 0.8rem;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  list-style: none;
-  padding: 0.7rem 1.5rem;
-  text-transform: uppercase;
-  color: #64748b;
-  user-select: none;
-}
-
-#blueprint-section summary::-webkit-details-marker { display: none; }
-#blueprint-section summary::before {
-  content: '▶';
-  font-size: 0.6rem;
-  transition: transform 0.15s;
-}
-#blueprint-section[open] > summary::before { transform: rotate(90deg); }
-#blueprint-section[open] > summary { color: #94a3b8; }
 
 .badge {
   background: #1e3a5f;
@@ -258,12 +228,13 @@ header p {
   flex-shrink: 0;
 }
 
-#blueprint-section .bfs-collapsible[open] > .bfs-summary::before {
+.blueprint-body .bfs-collapsible[open] > .bfs-summary::before {
   transform: rotate(90deg);
 }
 
-#blueprint-section .bfs-collapsible[open] > .bfs-summary {
+.blueprint-body .bfs-collapsible[open] > .bfs-summary {
   color: #e2e8f0;
+  margin-bottom: 0.75rem;
 }
 
 .bfs-json-preview {
@@ -1379,7 +1350,6 @@ header p {
   height: 100%;
 }
 
-.sidebar-content > details[open] > .blueprint-body,
 .sidebar-content > details[open] > .recording-settings-body,
 .sidebar-content > details[open] > .recordings-body,
 .sidebar-content > details[open] > .saved-scripts-body,

--- a/public/style.css
+++ b/public/style.css
@@ -773,6 +773,8 @@ header p {
 
 .script-settings-header {
   align-items: center;
+  container-name: script-settings;
+  container-type: inline-size;
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
@@ -782,11 +784,12 @@ header p {
 
 .script-settings-tabs {
   align-items: center;
-  display: flex;
-  flex: 1 1 auto;
-  flex-wrap: wrap;
+  display: grid;
+  flex: 1 1 100%;
   gap: 0.3rem;
+  grid-template-columns: minmax(0, 1fr);
   min-width: 0;
+  width: 100%;
 }
 
 .script-settings-tab {
@@ -800,11 +803,14 @@ header p {
   font-size: 0.72rem;
   font-weight: 600;
   gap: 0.45rem;
+  justify-content: flex-start;
   letter-spacing: 0.05em;
+  min-width: 0;
   padding: 0.32rem 0.65rem;
   text-transform: uppercase;
   transition: background 0.15s, border-color 0.15s, color 0.15s;
   white-space: nowrap;
+  width: 100%;
 }
 
 .script-settings-tab:hover {
@@ -821,6 +827,29 @@ header p {
 .script-settings-tab-panel {
   max-width: 100%;
   min-width: 0;
+}
+
+.script-settings-tab #step-count,
+.script-settings-tab .blueprint-pool-indicators--tab {
+  margin-left: auto;
+}
+
+@container script-settings (min-width: 500px) {
+  .script-settings-tabs {
+    display: flex;
+    flex: 1 1 auto;
+    flex-wrap: wrap;
+    width: auto;
+  }
+
+  .script-settings-tab {
+    width: auto;
+  }
+
+  .script-settings-tab #step-count,
+  .script-settings-tab .blueprint-pool-indicators--tab {
+    margin-left: 0;
+  }
 }
 
 .panel-header h2 {

--- a/public/style.css
+++ b/public/style.css
@@ -709,6 +709,54 @@ header p {
   max-height: calc(100vh - 220px);
 }
 
+#directions-panel,
+#steps-json-view,
+.blueprint-body--embedded,
+.blueprint-body--embedded .bfs-json-preview {
+  scrollbar-color: #334155 #0b1020;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+}
+
+#directions-panel::-webkit-scrollbar,
+#steps-json-view::-webkit-scrollbar,
+.blueprint-body--embedded::-webkit-scrollbar,
+.blueprint-body--embedded .bfs-json-preview::-webkit-scrollbar {
+  height: 10px;
+  width: 10px;
+}
+
+#directions-panel::-webkit-scrollbar-track,
+#steps-json-view::-webkit-scrollbar-track,
+.blueprint-body--embedded::-webkit-scrollbar-track,
+.blueprint-body--embedded .bfs-json-preview::-webkit-scrollbar-track {
+  background: #0b1020;
+  border-radius: 999px;
+}
+
+#directions-panel::-webkit-scrollbar-thumb,
+#steps-json-view::-webkit-scrollbar-thumb,
+.blueprint-body--embedded::-webkit-scrollbar-thumb,
+.blueprint-body--embedded .bfs-json-preview::-webkit-scrollbar-thumb {
+  background: #263449;
+  border: 2px solid #0b1020;
+  border-radius: 999px;
+}
+
+#directions-panel::-webkit-scrollbar-thumb:hover,
+#steps-json-view::-webkit-scrollbar-thumb:hover,
+.blueprint-body--embedded::-webkit-scrollbar-thumb:hover,
+.blueprint-body--embedded .bfs-json-preview::-webkit-scrollbar-thumb:hover {
+  background: #3a4b66;
+}
+
+#directions-panel::-webkit-scrollbar-corner,
+#steps-json-view::-webkit-scrollbar-corner,
+.blueprint-body--embedded::-webkit-scrollbar-corner,
+.blueprint-body--embedded .bfs-json-preview::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
 .panel-header {
   display: flex;
   align-items: center;

--- a/public/style.css
+++ b/public/style.css
@@ -86,6 +86,7 @@ header p {
 .badge.hidden { display: none; }
 
 .blueprint-body {
+  min-width: 0;
   padding: 0;
 }
 
@@ -93,6 +94,8 @@ header p {
   background: #111827;
   border: 1px solid #1e2433;
   border-radius: 6px;
+  max-width: 100%;
+  min-width: 0;
   overflow: hidden;
 }
 
@@ -213,6 +216,7 @@ header p {
 /* ── Collapsible blueprint form sections ─────────────────── */
 
 .bfs-collapsible {
+  min-width: 0;
   padding: 0 0.75rem;
 }
 
@@ -252,6 +256,7 @@ header p {
   padding: 8px;
   font-size: 11px;
   font-family: monospace;
+  max-width: 100%;
   max-height: 240px;
   overflow: auto;
   white-space: pre;
@@ -274,6 +279,7 @@ header p {
 .blueprint-form-section {
   border-top: 1px solid #1e2433;
   background: #0d1120;
+  min-width: 0;
   padding: 0.5rem 0;
 }
 
@@ -292,6 +298,7 @@ header p {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  min-width: 0;
   padding: 0 0.5rem;
 }
 
@@ -299,12 +306,14 @@ header p {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+  min-width: 0;
 }
 
 .bf-field-pair {
   display: grid;
   gap: 1rem;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  min-width: 0;
 }
 
 .bf-label {
@@ -347,6 +356,7 @@ header p {
 .bf-landing-page-row {
   display: flex;
   gap: 0.5rem;
+  min-width: 0;
 }
 
 .bf-landing-page-row .bf-input { flex: 1; min-width: 0; }
@@ -368,6 +378,7 @@ header p {
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
+  min-width: 0;
 }
 
 .bf-toggle-title {
@@ -696,7 +707,7 @@ header p {
 
 .workspace {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: 0;
   flex: 1;
   overflow: hidden;
@@ -704,55 +715,67 @@ header p {
 }
 
 .panel {
+  min-width: 0;
   padding: 1rem 1.5rem;
   overflow-y: auto;
   max-height: calc(100vh - 220px);
 }
 
-#directions-panel,
+#directions-panel {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 220px);
+  min-height: 0;
+  overflow: visible;
+}
+
+.script-settings-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding-right: 0.35rem;
+}
+
+.script-settings-scroll,
 #steps-json-view,
-.blueprint-body--embedded,
 .blueprint-body--embedded .bfs-json-preview {
   scrollbar-color: #334155 #0b1020;
   scrollbar-gutter: stable;
   scrollbar-width: thin;
 }
 
-#directions-panel::-webkit-scrollbar,
+.script-settings-scroll::-webkit-scrollbar,
 #steps-json-view::-webkit-scrollbar,
-.blueprint-body--embedded::-webkit-scrollbar,
 .blueprint-body--embedded .bfs-json-preview::-webkit-scrollbar {
   height: 10px;
   width: 10px;
 }
 
-#directions-panel::-webkit-scrollbar-track,
+.script-settings-scroll::-webkit-scrollbar-track,
 #steps-json-view::-webkit-scrollbar-track,
-.blueprint-body--embedded::-webkit-scrollbar-track,
 .blueprint-body--embedded .bfs-json-preview::-webkit-scrollbar-track {
   background: #0b1020;
   border-radius: 999px;
 }
 
-#directions-panel::-webkit-scrollbar-thumb,
+.script-settings-scroll::-webkit-scrollbar-thumb,
 #steps-json-view::-webkit-scrollbar-thumb,
-.blueprint-body--embedded::-webkit-scrollbar-thumb,
 .blueprint-body--embedded .bfs-json-preview::-webkit-scrollbar-thumb {
   background: #263449;
   border: 2px solid #0b1020;
   border-radius: 999px;
 }
 
-#directions-panel::-webkit-scrollbar-thumb:hover,
+.script-settings-scroll::-webkit-scrollbar-thumb:hover,
 #steps-json-view::-webkit-scrollbar-thumb:hover,
-.blueprint-body--embedded::-webkit-scrollbar-thumb:hover,
 .blueprint-body--embedded .bfs-json-preview::-webkit-scrollbar-thumb:hover {
   background: #3a4b66;
 }
 
-#directions-panel::-webkit-scrollbar-corner,
+.script-settings-scroll::-webkit-scrollbar-corner,
 #steps-json-view::-webkit-scrollbar-corner,
-.blueprint-body--embedded::-webkit-scrollbar-corner,
 .blueprint-body--embedded .bfs-json-preview::-webkit-scrollbar-corner {
   background: transparent;
 }
@@ -812,6 +835,7 @@ header p {
 }
 
 .script-settings-tab-panel {
+  max-width: 100%;
   min-width: 0;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -520,30 +520,6 @@ header p {
 
 /* ── Recording settings section ─────────────────────────── */
 
-#recording-settings-section summary {
-  align-items: center;
-  cursor: pointer;
-  display: flex;
-  gap: 0.6rem;
-  font-size: 0.8rem;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  list-style: none;
-  padding: 0.7rem 1.5rem;
-  text-transform: uppercase;
-  color: #64748b;
-  user-select: none;
-}
-
-#recording-settings-section summary::-webkit-details-marker { display: none; }
-#recording-settings-section summary::before {
-  content: '▶';
-  font-size: 0.6rem;
-  transition: transform 0.15s;
-}
-#recording-settings-section[open] summary::before { transform: rotate(90deg); }
-#recording-settings-section[open] summary { color: #94a3b8; }
-
 .recording-settings-body {
   display: flex;
   flex-direction: column;
@@ -1350,7 +1326,6 @@ header p {
   height: 100%;
 }
 
-.sidebar-content > details[open] > .recording-settings-body,
 .sidebar-content > details[open] > .recordings-body,
 .sidebar-content > details[open] > .saved-scripts-body,
 .sidebar-content > details[open] > .directions-body {

--- a/public/style.css
+++ b/public/style.css
@@ -89,6 +89,13 @@ header p {
   padding: 0;
 }
 
+.blueprint-body--embedded {
+  background: #111827;
+  border: 1px solid #1e2433;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
 .blueprint-panel-actions {
   display: flex;
   align-items: center;
@@ -543,6 +550,12 @@ header p {
   padding: 0.75rem 1.5rem 1rem;
 }
 
+.recording-settings-body--embedded {
+  background: #111827;
+  border: 1px solid #1e2433;
+  border-radius: 6px;
+}
+
 .setting-field {
   display: flex;
   flex-direction: column;
@@ -692,12 +705,59 @@ header p {
   max-height: calc(100vh - 220px);
 }
 
-
 .panel-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   margin-bottom: 0.75rem;
+}
+
+.script-settings-header {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.script-settings-tabs {
+  align-items: center;
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  min-width: 0;
+}
+
+.script-settings-tab {
+  background: transparent;
+  border: 1px solid #2d3748;
+  border-radius: 6px;
+  color: #64748b;
+  cursor: pointer;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  padding: 0.32rem 0.65rem;
+  text-transform: uppercase;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.script-settings-tab:hover {
+  border-color: #6b7280;
+  color: #94a3b8;
+}
+
+.script-settings-tab.active {
+  background: #1a2035;
+  border-color: #6366f1;
+  color: #e2e8f0;
+}
+
+.script-settings-tab-panel {
+  min-width: 0;
 }
 
 .panel-header h2 {

--- a/public/style.css
+++ b/public/style.css
@@ -113,7 +113,11 @@ header p {
   display: flex;
   flex-shrink: 0;
   gap: 0.35rem;
-  margin: 0 auto 0 0;
+  margin: 0;
+}
+
+.blueprint-pool-indicators--tab {
+  gap: 0.25rem;
 }
 
 .blueprint-pool-indicator {
@@ -731,13 +735,16 @@ header p {
 }
 
 .script-settings-tab {
+  align-items: center;
   background: transparent;
   border: 1px solid #2d3748;
   border-radius: 6px;
   color: #64748b;
   cursor: pointer;
+  display: inline-flex;
   font-size: 0.72rem;
   font-weight: 600;
+  gap: 0.45rem;
   letter-spacing: 0.05em;
   padding: 0.32rem 0.65rem;
   text-transform: uppercase;

--- a/public/style.css
+++ b/public/style.css
@@ -1268,6 +1268,7 @@ header p {
   color: #94a3b8;
   cursor: pointer;
   font-size: 0.85rem;
+  line-height: 1.2;
   padding: 0.4rem 0.9rem;
   transition: border-color 0.15s, color 0.15s;
 }
@@ -1278,14 +1279,15 @@ header p {
 
 .direction-bar button.primary {
   background: #16a34a;
-  border: none;
+  border: 1px solid transparent;
   border-radius: 6px;
   color: #fff;
   cursor: pointer;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   font-weight: 600;
+  line-height: 1.2;
   margin-left: auto;
-  padding: 0.45rem 1.4rem;
+  padding: 0.4rem 1.4rem;
   transition: background 0.15s;
 }
 
@@ -1294,14 +1296,15 @@ header p {
 
 .direction-bar button.danger {
   background: #dc2626;
-  border: none;
+  border: 1px solid transparent;
   border-radius: 6px;
   color: #fff;
   cursor: pointer;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   font-weight: 600;
+  line-height: 1.2;
   margin-left: auto;
-  padding: 0.45rem 1.2rem;
+  padding: 0.4rem 1.2rem;
   transition: background 0.15s;
 }
 
@@ -1774,8 +1777,8 @@ header p {
 }
 
 @keyframes preview-pulse {
-  0%, 100% { box-shadow: 0 0 0 1px #6366f1; }
-  50%       { box-shadow: 0 0 8px 3px #6366f140; }
+  0%, 100% { box-shadow: inset 0 0 0 1px #6366f1; }
+  50%       { box-shadow: inset 0 0 10px 2px #6366f140; }
 }
 
 

--- a/public/style.css
+++ b/public/style.css
@@ -293,13 +293,6 @@ header p {
 
 .blueprint-form-section:first-of-type { border-top: none; }
 
-
-.blueprint-form-section-placeholder {
-  color: #4b5563;
-  font-size: 0.85rem;
-  font-style: italic;
-}
-
 /* ── Blueprint form fields ───────────────────────────────── */
 
 .bf-fields {
@@ -507,20 +500,6 @@ header p {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.bf-item-toggle {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  cursor: pointer;
-  flex-shrink: 0;
-}
-
-.bf-item-toggle-label {
-  font-size: 0.8rem;
-  color: #94a3b8;
-  user-select: none;
 }
 
 .bf-remove-btn {
@@ -764,13 +743,6 @@ header p {
   background: transparent;
 }
 
-.panel-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 0.75rem;
-}
-
 .script-settings-header {
   align-items: center;
   container-name: script-settings;
@@ -850,10 +822,6 @@ header p {
   .script-settings-tab .blueprint-pool-indicators--tab {
     margin-left: 0;
   }
-}
-
-.panel-header h2 {
-  margin-bottom: 0;
 }
 
 .panel h2 {
@@ -1133,36 +1101,6 @@ header p {
   border-radius: 3px 3px 0 0;
 }
 
-.direction-toggle {
-  background: none;
-  border: none;
-  color: #475569;
-  cursor: pointer;
-  font-size: 0.65rem;
-  line-height: 1;
-  padding: 0.2rem 0.3rem;
-  border-radius: 3px;
-  transition: color 0.15s, background 0.15s;
-  flex-shrink: 0;
-}
-
-.direction-toggle:hover { color: #94a3b8; background: #252d3d; }
-
-.direction-delete {
-  background: none;
-  border: none;
-  color: #374151;
-  cursor: pointer;
-  font-size: 0.7rem;
-  line-height: 1;
-  padding: 0.2rem 0.3rem;
-  border-radius: 3px;
-  transition: color 0.15s, background 0.15s;
-  flex-shrink: 0;
-}
-
-.direction-delete:hover { color: #f87171; background: #2d1f1f; }
-
 .direction-inner-list {
   list-style: none;
   border-top: 1px solid #232d40;
@@ -1201,35 +1139,6 @@ header p {
   text-transform: none;
   letter-spacing: 0;
 }
-
-#json-preview {
-  background: #111827;
-  border: 1px solid #1e2433;
-  border-radius: 6px;
-  color: #86efac;
-  font-family: 'Menlo', 'Monaco', monospace;
-  font-size: 0.78rem;
-  line-height: 1.6;
-  outline: none;
-  padding: 0.75rem 1rem;
-  resize: none;
-  white-space: pre;
-  width: 100%;
-  height: calc(100% - 2rem);
-  min-height: 200px;
-  transition: border-color 0.15s;
-}
-
-#json-preview:focus { border-color: #6366f1; }
-#json-preview.invalid { border-color: #ef4444; }
-
-.json-error {
-  color: #f87171;
-  font-size: 0.78rem;
-  margin-top: 0.4rem;
-}
-
-.json-error.hidden { display: none; }
 
 .direction-bar {
   align-items: center;
@@ -1844,20 +1753,6 @@ header p {
   white-space: nowrap;
 }
 
-.direction-item .direction-insert-btn {
-  background: transparent;
-  border: 1px solid #374151;
-  border-radius: 5px;
-  color: #94a3b8;
-  cursor: pointer;
-  font-size: 0.78rem;
-  padding: 0.2rem 0.6rem;
-  transition: border-color 0.15s, color 0.15s;
-  white-space: nowrap;
-}
-
-.direction-item .direction-insert-btn:hover { border-color: #6b7280; color: #e2e8f0; }
-
 .direction-item .direction-delete-btn {
   background: transparent;
   border: 1px solid #4b1c1c;
@@ -1879,47 +1774,6 @@ header p {
 }
 
 .direction-item--builtin .direction-name { color: #94a3b8; }
-
-.direction-save {
-  background: none;
-  border: none;
-  color: #374151;
-  cursor: pointer;
-  font-size: 0.75rem;
-  line-height: 1;
-  padding: 0.2rem 0.3rem;
-  border-radius: 3px;
-  transition: color 0.15s, background 0.15s;
-  flex-shrink: 0;
-}
-
-.direction-save:hover { color: #60a5fa; background: #1a2535; }
-
-/* ── Direction insert button (per action) ────────────────────────────────────── */
-.direction-insert {
-  background: none;
-  border: 1px solid #2d3a50;
-  border-radius: 50%;
-  color: #4b6080;
-  cursor: pointer;
-  font-size: 0.75rem;
-  font-weight: 600;
-  line-height: 1;
-  width: 1.1rem;
-  height: 1.1rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  flex-shrink: 0;
-  transition: border-color 0.15s, color 0.15s, background 0.15s;
-}
-
-.direction-insert:hover {
-  border-color: #60a5fa;
-  color: #60a5fa;
-  background: #1a2535;
-}
 
 /* ── Bottom insert button ────────────────────────────────────────────────────── */
 #direction-insert-bottom {


### PR DESCRIPTION
Now that directions+blueprint+recording settings combine into a single save file, it makes sense to reorganize these so they are grouped together to make it clear what you are saving and loading.
In addition, this provides more breathing room for the blueprint settings, which were pretty smooshed together before.

This patch also sneaks in a few more adjustments:
- Scroll design and layout improvements for the directions section
- Remove unused CSS
- Refactor class assignment logic to use clsx and to avoid class name stitching
- Drop unused section code (e.g. the embedded prop for the Blueprint and Recording sections)
- Renamed "Save" to "Apply" under Blueprint settings to avoid confusion between saving a script and applying blueprint changes.