### PR TITLE
DEVREL-1407: Fix squashed Insert Directions dropdown

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1948,7 +1948,7 @@ header p {
   flex-direction: column;
   min-width: 200px;
   max-width: 280px;
-  max-height: 280px;
+  max-height: min(360px, calc(100vh - 120px));
   overflow-y: auto;
   padding: 0.3rem 0;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -1958,6 +1958,7 @@ header p {
   border: none;
   color: #cbd5e1;
   cursor: pointer;
+  flex-shrink: 0;
   font-size: 0.85rem;
   padding: 0.45rem 1rem;
   text-align: left;
@@ -1973,6 +1974,7 @@ header p {
 
 .direction-picker-position {
   display: flex;
+  flex-shrink: 0;
   gap: 0;
   padding: 0.3rem 0.5rem;
 }
@@ -1999,5 +2001,6 @@ header p {
 
 .direction-picker-divider {
   border-top: 1px solid #2d3a50;
+  flex-shrink: 0;
   margin: 0.2rem 0;
 }


### PR DESCRIPTION
## Summary
- Fix the Insert Directions picker shrinking its items vertically when there are more entries than fit in the dropdown — flex children inherited `flex-shrink: 1`, so content was compressed instead of scrolling.
- Pin `.direction-picker-item`, `.direction-picker-position`, and `.direction-picker-divider` to `flex-shrink: 0` so items keep their natural height and the container scrolls within its cap.
- Make the dropdown's `max-height` responsive: `min(360px, calc(100vh - 120px))` so it uses more space on tall screens and stays clear of the viewport edge on short ones.

Closes DEVREL-1407

## Test plan
- [ ] Save 8+ directions, open a direction's `⋯` menu → Insert direction; confirm items render at full height and the list scrolls instead of squashing.
- [ ] Resize the window short (~500px tall) and re-open the picker; confirm it doesn't run off the bottom of the viewport.
- [ ] Resize the window tall (>900px) and re-open; confirm the picker grows up to 360px before scrolling.