### PR TITLE
DEVREL-1406.: Speed up Playwright step execution

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -25,9 +25,6 @@ module.exports = defineConfig({
     },
     trace: 'on',    // always record trace for interactive replay
     screenshot: 'on', // capture screenshots on each step
-    launchOptions: {
-      slowMo: 500,  // slow down actions so the recording is easier to follow
-    },
   },
   projects: [
     {

--- a/recordings/actions-runner.spec.js
+++ b/recordings/actions-runner.spec.js
@@ -29,6 +29,8 @@ for (const file of stepFiles) {
   const def = JSON.parse(fs.readFileSync(path.join(stepsDir, file), 'utf8'));
 
   test(def.name, async ({ page }) => {
+    const landingPage = def.blueprint?.landingPage || '/wp-admin/';
+    await page.goto(landingPage);
     await runSteps(page, def, async ( step, exec ) => await test.step( step.action + ( step.selector ? ` "${ step.selector }"` : '' ), exec ));
   });
 }

--- a/recordings/run-steps.js
+++ b/recordings/run-steps.js
@@ -177,18 +177,14 @@ async function runStep(step, page, frameStack, ctx, sidebar, settings = { typing
       const pluginSearchInput = page.locator('#search-plugins');
       await pluginSearchInput.waitFor({ state: 'visible' });
       await typeSlow(pluginSearchInput, step.slug, stepTypingDelay(step, settings));
-      await page.waitForLoadState('networkidle');
-      await page.waitForTimeout(800);
       const installBtn = page.locator(`.plugin-card-${step.slug} .install-now`);
       await installBtn.waitFor({ timeout: 15_000 });
       await highlightAndClick(page, installBtn);
       const activateBtn = page.locator(`.plugin-card-${step.slug} .activate-now`);
       await activateBtn.waitFor({ timeout: 30_000 });
-      await page.waitForTimeout(600);
       if (step.activate) {
         await highlightAndClick(page, activateBtn);
-        await page.waitForLoadState('networkidle');
-        await page.waitForTimeout(800);
+        await page.waitForLoadState('domcontentloaded');
       }
       break;
     }
@@ -200,7 +196,6 @@ async function runStep(step, page, frameStack, ctx, sidebar, settings = { typing
       const searchInput = page.locator('#wp-filter-search-input');
       await searchInput.waitFor({ state: 'visible' });
       await typeSlow(searchInput, step.slug, stepTypingDelay(step, settings));
-      await page.waitForLoadState('networkidle');
       const themeInstallBtn = page.locator(`[aria-label="Install ${displayName}"]`);
       await themeInstallBtn.waitFor({ timeout: 15_000 });
       await themeInstallBtn.hover();
@@ -209,7 +204,7 @@ async function runStep(step, page, frameStack, ctx, sidebar, settings = { typing
       await themeActivateBtn.waitFor({ timeout: 30_000 });
       if (step.activate) {
         await highlightAndClick(page, themeActivateBtn);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
       }
       break;
     }
@@ -223,7 +218,6 @@ async function runStep(step, page, frameStack, ctx, sidebar, settings = { typing
       } else {
         await typeSlow(titleLocator, step.title, stepTypingDelay(step, settings));
       }
-      await page.waitForTimeout(300);
       break;
     }
 
@@ -245,7 +239,6 @@ async function runStep(step, page, frameStack, ctx, sidebar, settings = { typing
       await targetLocator.scrollIntoViewIfNeeded();
       await targetLocator.click({ clickCount: replace ? 3 : 1 });
       await targetLocator.pressSequentially(step.content, { delay });
-      await page.waitForTimeout(300);
       break;
     }
 
@@ -257,7 +250,6 @@ async function runStep(step, page, frameStack, ctx, sidebar, settings = { typing
       await block.waitFor({ state: 'visible', timeout: 10_000 });
       await block.click();
       await block.and(editorFrame.locator('.is-selected')).waitFor({ state: 'visible', timeout: 5_000 });
-      await page.waitForTimeout(400);
       break;
     }
 
@@ -267,42 +259,21 @@ async function runStep(step, page, frameStack, ctx, sidebar, settings = { typing
         : step.blockType;
       const editorFrame = page.frameLocator('iframe[name="editor-canvas"]');
 
-      if (step.afterIndex !== undefined && step.afterIndex >= 0) {
-        // Insert an empty paragraph at the exact position and use its clientId
-        // to click it directly — avoids focus/keyboard state issues entirely.
-        const newClientId = await page.evaluate((idx) => {
-          const newBlock = wp.blocks.createBlock('core/paragraph');
-          wp.data.dispatch('core/block-editor').insertBlock(newBlock, idx + 1);
-          return newBlock.clientId;
-        }, step.afterIndex);
-        await page.waitForTimeout(300);
-        const newBlockEl = editorFrame.locator(`[data-block="${newClientId}"]`);
-        await newBlockEl.waitFor({ state: 'visible', timeout: 5_000 });
-        await newBlockEl.click();
-      } else {
-        // Insert at the end
-        const appender = editorFrame.getByRole('button', { name: 'Add default block' });
-        try {
-          await appender.waitFor({ state: 'visible', timeout: 3_000 });
-          await appender.click();
-        } catch {
-          // No appender — move cursor to absolute end of last text block, then Enter if it has content
-          const lastEditable = editorFrame.locator('[contenteditable="true"]:not(.wp-block-post-title)').last();
-          await lastEditable.click();
-          const isEmpty = (await lastEditable.textContent()) === '';
-          if (!isEmpty) {
-            await lastEditable.evaluate(el => {
-              const range = document.createRange();
-              range.selectNodeContents(el);
-              range.collapse(false);
-              const sel = window.getSelection();
-              sel.removeAllRanges();
-              sel.addRange(range);
-            });
-            await page.keyboard.press('Enter');
-          }
-        }
-      }
+      // Insert an empty paragraph programmatically at the target position, then
+      // click it to focus. Avoids the DOM appender race and the unreliable
+      // "click + Enter to split" fallback, both of which produced
+      // mid-word block splits when Gutenberg's internal selection state
+      // didn't match the DOM selection.
+      const newClientId = await page.evaluate((idx) => {
+        const newBlock = wp.blocks.createBlock('core/paragraph');
+        const order = wp.data.select('core/block-editor').getBlockOrder();
+        const position = idx !== undefined && idx >= 0 ? idx + 1 : order.length;
+        wp.data.dispatch('core/block-editor').insertBlock(newBlock, position);
+        return newBlock.clientId;
+      }, step.afterIndex);
+      const newBlockEl = editorFrame.locator(`[data-block="${newClientId}"]`);
+      await newBlockEl.waitFor({ state: 'visible', timeout: 5_000 });
+      await newBlockEl.click();
 
       // Paragraph is the default block — no slash command needed
       if (shortName !== 'paragraph') {
@@ -312,8 +283,10 @@ async function runStep(step, page, frameStack, ctx, sidebar, settings = { typing
         await option.waitFor({ state: 'visible', timeout: 5_000 });
         await option.click();
         await page.keyboard.press('Enter');
+        // Wait for the autocomplete to close — confirms the block was inserted
+        // and the editor is settled before the next step runs.
+        await option.waitFor({ state: 'hidden', timeout: 5_000 });
       }
-      await page.waitForTimeout(400);
       break;
     }
 
@@ -333,36 +306,39 @@ async function runStep(step, page, frameStack, ctx, sidebar, settings = { typing
       const blockType = step.blockType.includes('/') ? step.blockType : `core/${step.blockType}`;
       const index = step.index ?? 0;
       const editorFrame = page.frameLocator('iframe[name="editor-canvas"]');
-      await editorFrame.locator(`[data-type="${blockType}"]`).nth(index).click();
-      await page.waitForTimeout(200);
+      const blocks = editorFrame.locator(`[data-type="${blockType}"]`);
+      const target = blocks.nth(index);
+      const beforeCount = await blocks.count();
+      await target.click();
+      await target.and(editorFrame.locator('.is-selected')).waitFor({ state: 'visible', timeout: 5_000 });
       await page.keyboard.press('Escape');
-      await page.waitForTimeout(200);
       await page.keyboard.press('Backspace');
-      await page.waitForTimeout(300);
+      if (beforeCount > 0) {
+        const deadline = Date.now() + 5_000;
+        while (Date.now() < deadline && (await blocks.count()) >= beforeCount) {
+          await page.waitForTimeout(50);
+        }
+      }
       break;
     }
 
     case 'wpSiteEditorSave': {
       await page.getByRole('button', { name: 'Save', exact: true }).click();
-      await page.waitForTimeout(500);
       const publishPanel = page.getByRole('region', { name: 'Editor publish' });
       await publishPanel.waitFor({ state: 'visible', timeout: 10_000 });
       await publishPanel.getByRole('button', { name: 'Save', exact: true }).click();
-      await page.waitForTimeout(800);
+      await publishPanel.waitFor({ state: 'hidden', timeout: 10_000 });
       break;
     }
 
     case 'wpInsertBlockFromPanel': {
       await page.getByRole('button', { name: 'Block Inserter', exact: true }).click();
-      await page.waitForTimeout(400);
       const blockLibrary = page.getByRole('region', { name: 'Block Library' });
       await blockLibrary.waitFor({ state: 'visible', timeout: 10_000 });
       await blockLibrary.getByRole('searchbox', { name: 'Search' }).fill(step.blockType);
-      await page.waitForTimeout(400);
       const option = page.getByRole('option', { name: step.blockType, exact: true });
       await option.waitFor({ timeout: 5_000 });
       await option.click();
-      await page.waitForTimeout(400);
       break;
     }
 
@@ -375,7 +351,6 @@ async function runStep(step, page, frameStack, ctx, sidebar, settings = { typing
         await sidebar.waitFor({ state: 'visible', timeout: 5_000 });
       }
       await sidebar.getByRole('button', { name: step.panel }).click();
-      await page.waitForTimeout(300);
       break;
     }
 
@@ -400,7 +375,6 @@ async function runStep(step, page, frameStack, ctx, sidebar, settings = { typing
     case 'wpEditorWPMenuClick': {
       // Click the WordPress logo button at the top-left of the block editor.
       await highlightAndClick(page, page.getByRole('button', { name: 'WordPress', exact: true }));
-      await page.waitForTimeout(300);
       break;
     }
 
@@ -409,7 +383,6 @@ async function runStep(step, page, frameStack, ctx, sidebar, settings = { typing
       // Pass `enable: false` to turn fullscreen off (reveals the WP admin sidebar).
       const optionsBtn = page.getByRole('button', { name: 'Options', exact: true });
       await highlightAndClick(page, optionsBtn);
-      await page.waitForTimeout(300);
       const prefsItem = page.getByRole('menuitem', { name: 'Preferences' });
       await prefsItem.waitFor({ state: 'visible', timeout: 5_000 });
       await prefsItem.click();
@@ -420,10 +393,9 @@ async function runStep(step, page, frameStack, ctx, sidebar, settings = { typing
       const shouldEnable = step.enable !== false;
       if (shouldEnable !== await toggle.isChecked()) {
         await toggle.click();
-        await page.waitForTimeout(300);
       }
       await modal.getByRole('button', { name: 'Close' }).click();
-      await page.waitForTimeout(300);
+      await modal.waitFor({ state: 'hidden', timeout: 5_000 });
       break;
     }
 

--- a/recordings/run-steps.js
+++ b/recordings/run-steps.js
@@ -177,6 +177,8 @@ async function runStep(step, page, frameStack, ctx, sidebar, settings = { typing
       const pluginSearchInput = page.locator('#search-plugins');
       await pluginSearchInput.waitFor({ state: 'visible' });
       await typeSlow(pluginSearchInput, step.slug, stepTypingDelay(step, settings));
+      const submitBtn = page.locator('#search-submit');
+      await submitBtn.click();
       const installBtn = page.locator(`.plugin-card-${step.slug} .install-now`);
       await installBtn.waitFor({ timeout: 15_000 });
       await highlightAndClick(page, installBtn);

--- a/recordings/run-steps.js
+++ b/recordings/run-steps.js
@@ -7,7 +7,7 @@
  * `runPlaywrightApi` in `server/routes/runner.js` (Playwright library API).
  */
 
-const HIGHLIGHT_HOLD = 1000;
+const HIGHLIGHT_HOLD = 700;
 const DEFAULT_END_PAUSE = 2000;
 const DEFAULT_STEP_PAUSE = 0;
 const DEFAULT_TYPING_DELAY = 100;


### PR DESCRIPTION
## Summary

Cuts ~14s (~25%) off a typical recording run and fixes a pre-existing intermittent failure in `basic-insert`. Three commits:

1. **Remove `slowMo: 500` from `playwright.config.js`** — was adding 500ms after every Playwright primitive (clicks, waits, individual keystrokes) on top of the explicit per-keystroke delay already controlled by Typing Speed. The two were doing overlapping but distinct work; Typing Speed now solely governs visible typing pacing, and every non-typing action gets ~500ms snappier. Also patches `actions-runner.spec.js` to navigate to the blueprint's `landingPage` before running steps (mirrors what the UI runner already does), so scripts that start in the editor (e.g. `basic-insert`) work via `npm run record:action`.

2. **Replace hardcoded `waitForTimeout`s in `run-steps.js` with condition-based waits** — most action handlers had 200–800ms pads right after they had already gated on a real condition. Drops the redundant pads in `wpSelectBlock`, `wpSetPostTitle`, `wpSetBlockContent`, `wpEditorWPMenuClick`, `wpInspectorPanel`, and `wpEditorToggleFullscreen`; replaces the trailing pads in `wpSiteEditorSave` and `wpEditorToggleFullscreen` with explicit "panel/modal is hidden" waits; drops the `networkidle` + 800/600ms pads from `wpInstallPlugin` and `wpInstallTheme`; replaces the 200/200/300ms triplet in `wpDeleteBlock` with a real wait for the block count to decrease.

   Same commit fixes a pre-existing `wpInsertBlock` flake. The at-end branch waited 3s for the DOM "Add default block" appender and, on timeout, fell through to a fragile fallback that clicked the last paragraph and pressed Enter to split it. Gutenberg's RichText component uses its own selection state, so a manual `range.collapse(false)` updated the DOM selection but not Gutenberg's internal selection — Enter then split at the click position (paragraph center) instead of the end, producing mid-word block splits like `hu` + `/imagemanity ever forward.`. Both `wpInsertBlock` branches now use programmatic insertion via `wp.data.dispatch('core/block-editor').insertBlock`, with the position computed from `getBlockOrder().length` for the at-end case.

3. **Tighten `HIGHLIGHT_HOLD` from 1000ms to 700ms** — still readable but distinctly snappier; saves ~300ms per `highlightClick`.

Resolves [DEVREL-1406](https://linear.app/a8c/issue/DEVREL-1406/there-seems-to-be-some-kind-of-delay-before-a-step-is-completed-and).

## Measurements (avg of 5 runs each)

| Script | Original `trunk` | This branch | Δ |
|---|---|---|---|
| Content Creation | 55.2s | ~41s | **−14s (−25%)** |
| Basic Insert | flaky (1/5 pass) | 5/5 pass at ~24s | **flake fixed** |

## Test plan

- [ ] `npm run record:action -- "Content Creation"` passes and is visibly faster
- [ ] `npm run record:action -- "Basic Insert"` passes consistently (run 3–5×)
- [ ] `npm run record:action -- "Admin Sidebar: Posts"` still passes
- [ ] Run a recording through the UI (`npm start`) and confirm the produced video still looks good — typing pacing intact, highlight rings still visible
- [ ] Spot-check a `wpInstallPlugin` / `wpInstallTheme` flow (no longer relies on `networkidle`)
- [ ] Verify `wpSiteEditorSave` flow on a site-editor recording

🤖 Generated with [Claude Code](https://claude.com/claude-code)