### PR TITLE
DEVREL-1408: Reset directions, blueprint, and settings via Clear and UI updates

### DIFF
--- a/client/DirectionToolbar.jsx
+++ b/client/DirectionToolbar.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { toast } from 'react-toastify';
 import { useAppState } from './context/AppStateContext.jsx';
 import { useRunState } from './context/RunContext.jsx';
+import { Dialog } from './Dialog.jsx';
 import { ScriptNameDialog } from './ScriptNameDialog.jsx';
 import { errorMessage } from './utils/actions.js';
 import { useSaveScriptMutation } from './utils/apiHooks.js';
@@ -24,6 +25,8 @@ export function DirectionToolbar() {
   const { running, runActions, stopRun } = useRunState();
   const saveScriptMutation = useSaveScriptMutation();
   const [pendingNamedAction, setPendingNamedAction] = useState(null);
+  const [clearDialogOpen, setClearDialogOpen] = useState(false);
+  const [clearing, setClearing] = useState(false);
   const hasResolvedDirections = runDirections.length > 0;
   const poolLabel = poolStatus.ready ? null : `Playground warming up (${poolStatus.warm}/${poolStatus.total} ready). The run will start when an instance is available.`;
   const currentScriptName = name.trim();
@@ -119,7 +122,7 @@ export function DirectionToolbar() {
         <button className="secondary" type="button" disabled={!hasResolvedDirections} onClick={() => runWithScriptName('export')}>
           Export TXT
         </button>
-        <button className="secondary" type="button" onClick={clearDirections}>
+        <button className="secondary" type="button" onClick={() => setClearDialogOpen(true)}>
           Clear
         </button>
 
@@ -161,6 +164,44 @@ export function DirectionToolbar() {
           onCancel={() => setPendingNamedAction(null)}
           onConfirm={confirmScriptName}
         />
+      )}
+
+      {clearDialogOpen && (
+        <Dialog
+          title="Clear workspace?"
+          description="This will remove all directions, reset recording settings to defaults, and reset the blueprint to the default. This cannot be undone."
+          closeDisabled={clearing}
+          onClose={() => { if (!clearing) setClearDialogOpen(false); }}
+        >
+          <div className="app-dialog-actions">
+            <button
+              className="app-dialog-btn app-dialog-btn--secondary"
+              type="button"
+              disabled={clearing}
+              onClick={() => setClearDialogOpen(false)}
+            >
+              Cancel
+            </button>
+            <button
+              className="app-dialog-btn app-dialog-btn--danger"
+              type="button"
+              disabled={clearing}
+              onClick={async () => {
+                setClearing(true);
+                try {
+                  await clearDirections();
+                  setClearDialogOpen(false);
+                } catch (err) {
+                  toast.error(errorMessage(err, 'Could not clear workspace'));
+                } finally {
+                  setClearing(false);
+                }
+              }}
+            >
+              {clearing ? 'Clearing...' : 'Clear'}
+            </button>
+          </div>
+        </Dialog>
       )}
     </>
   );

--- a/client/DirectionsPanel.jsx
+++ b/client/DirectionsPanel.jsx
@@ -157,6 +157,7 @@ export function DirectionsPanel() {
           aria-labelledby="script-tab-directions"
           hidden={activeTab !== 'directions'}
         >
+          <div className="tab-panel-body">
           <div className="directions-view-switcher">
             <div className="directions-view-toggle" role="group" aria-label="Directions view">
               <button
@@ -277,6 +278,7 @@ export function DirectionsPanel() {
           {directionsView === 'json' && (
             <pre id="steps-json-view">{JSON.stringify(cleanDirections, null, 2)}</pre>
           )}
+          </div>
         </div>
 
         <div

--- a/client/DirectionsPanel.jsx
+++ b/client/DirectionsPanel.jsx
@@ -158,126 +158,126 @@ export function DirectionsPanel() {
           hidden={activeTab !== 'directions'}
         >
           <div className="tab-panel-body">
-          <div className="directions-view-switcher">
-            <div className="directions-view-toggle" role="group" aria-label="Directions view">
-              <button
-                className={clsx('directions-view-toggle-btn', directionsView === 'actions' && 'active')}
-                type="button"
-                aria-pressed={directionsView === 'actions'}
-                onClick={() => setDirectionsView('actions')}
-              >
-                Actions
-              </button>
-              <button
-                className={clsx('directions-view-toggle-btn', directionsView === 'json' && 'active')}
-                type="button"
-                aria-pressed={directionsView === 'json'}
-                onClick={() => setDirectionsView('json')}
-              >
-                JSON
-              </button>
-            </div>
-          </div>
-
-          {directionsView === 'actions' && (
-            <>
-              <ul id="step-list">
-                {directions.map((direction, index) => {
-                  const isStartFrom = startFromIndex === index;
-                  const isAlwaysRun = alwaysRunIndices.has(index);
-                  const isSkipped = startFromIndex !== null && index < startFromIndex && !isAlwaysRun;
-
-                  return (
-                    <DirectionGroup
-                      key={direction._id ?? index}
-                      direction={direction}
-                      dragging={draggingIndex === index}
-                      dragOver={dragOverIndex === index}
-                      index={index}
-                      isAlwaysRun={isAlwaysRun}
-                      isActiveStep={activeStepIndex === index}
-                      isSkipped={isSkipped}
-                      isStartFrom={isStartFrom}
-                      itemRef={activeStepIndex === index ? activeDirectionRef : null}
-                      onDragStart={(event) => {
-                        if (event.target.tagName === 'INPUT') {
-                          event.preventDefault();
-                          return;
-                        }
-                        draggingIndexRef.current = index;
-                        setDraggingIndex(index);
-                        event.dataTransfer.effectAllowed = 'move';
-                        event.dataTransfer.setData('text/plain', String(index));
-                      }}
-                      onDragEnd={() => {
-                        draggingIndexRef.current = null;
-                        setDraggingIndex(null);
-                        setDragOverIndex(null);
-                      }}
-                      onDragOver={(event) => {
-                        event.preventDefault();
-                        event.dataTransfer.dropEffect = 'move';
-                        if (draggingIndexRef.current !== null && draggingIndexRef.current !== index) {
-                          setDragOverIndex(index);
-                        }
-                      }}
-                      onDragLeave={() => {
-                        setDragOverIndex((current) => (current === index ? null : current));
-                      }}
-                      onDrop={(event) => {
-                        event.preventDefault();
-                        const from = draggingIndexRef.current;
-                        if (from !== null && from !== index) {
-                          reorderDirections(from, index);
-                        }
-                        draggingIndexRef.current = null;
-                        setDraggingIndex(null);
-                        setDragOverIndex(null);
-                      }}
-                      onLabelChange={(label) => updateDirectionLabel(index, label)}
-                      onMenu={(event) => {
-                        event.stopPropagation();
-                        setPicker(null);
-                        setMenu({ index, position: menuPosition(event.currentTarget) });
-                      }}
-                      onToggleAlwaysRun={() => toggleAlwaysRun(index)}
-                      onToggleStartFrom={() => toggleStartFrom(index)}
-                    />
-                  );
-                })}
-              </ul>
-
-              {!hasDirections && <p id="empty-hint" className="hint">Type a command above, or insert a direction below.</p>}
-
-              <div id="direction-insert-bottom" className="directions-tab-actions">
+            <div className="directions-view-switcher">
+              <div className="directions-view-toggle" role="group" aria-label="Directions view">
                 <button
-                  className="direction-insert-plus direction-insert-plus--bottom"
-                  title="Insert direction"
+                  className={clsx('directions-view-toggle-btn', directionsView === 'actions' && 'active')}
                   type="button"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    setMenu(null);
-                    setPicker({ anchorIndex: null, position: pickerPosition(event.currentTarget) });
-                  }}
+                  aria-pressed={directionsView === 'actions'}
+                  onClick={() => setDirectionsView('actions')}
                 >
-                  + Insert direction
+                  Actions
                 </button>
                 <button
-                  className="direction-insert-plus direction-insert-plus--bottom"
-                  title="Clear all directions"
+                  className={clsx('directions-view-toggle-btn', directionsView === 'json' && 'active')}
                   type="button"
-                  disabled={!hasDirections}
-                  onClick={() => setClearDirectionsDialogOpen(true)}
+                  aria-pressed={directionsView === 'json'}
+                  onClick={() => setDirectionsView('json')}
                 >
-                  × Clear directions
+                  JSON
                 </button>
               </div>
-            </>
-          )}
-
-          {directionsView === 'json' && (
-            <pre id="steps-json-view">{JSON.stringify(cleanDirections, null, 2)}</pre>
-          )}
+            </div>
+  
+            {directionsView === 'actions' && (
+              <>
+                <ul id="step-list">
+                  {directions.map((direction, index) => {
+                    const isStartFrom = startFromIndex === index;
+                    const isAlwaysRun = alwaysRunIndices.has(index);
+                    const isSkipped = startFromIndex !== null && index < startFromIndex && !isAlwaysRun;
+  
+                    return (
+                      <DirectionGroup
+                        key={direction._id ?? index}
+                        direction={direction}
+                        dragging={draggingIndex === index}
+                        dragOver={dragOverIndex === index}
+                        index={index}
+                        isAlwaysRun={isAlwaysRun}
+                        isActiveStep={activeStepIndex === index}
+                        isSkipped={isSkipped}
+                        isStartFrom={isStartFrom}
+                        itemRef={activeStepIndex === index ? activeDirectionRef : null}
+                        onDragStart={(event) => {
+                          if (event.target.tagName === 'INPUT') {
+                            event.preventDefault();
+                            return;
+                          }
+                          draggingIndexRef.current = index;
+                          setDraggingIndex(index);
+                          event.dataTransfer.effectAllowed = 'move';
+                          event.dataTransfer.setData('text/plain', String(index));
+                        }}
+                        onDragEnd={() => {
+                          draggingIndexRef.current = null;
+                          setDraggingIndex(null);
+                          setDragOverIndex(null);
+                        }}
+                        onDragOver={(event) => {
+                          event.preventDefault();
+                          event.dataTransfer.dropEffect = 'move';
+                          if (draggingIndexRef.current !== null && draggingIndexRef.current !== index) {
+                            setDragOverIndex(index);
+                          }
+                        }}
+                        onDragLeave={() => {
+                          setDragOverIndex((current) => (current === index ? null : current));
+                        }}
+                        onDrop={(event) => {
+                          event.preventDefault();
+                          const from = draggingIndexRef.current;
+                          if (from !== null && from !== index) {
+                            reorderDirections(from, index);
+                          }
+                          draggingIndexRef.current = null;
+                          setDraggingIndex(null);
+                          setDragOverIndex(null);
+                        }}
+                        onLabelChange={(label) => updateDirectionLabel(index, label)}
+                        onMenu={(event) => {
+                          event.stopPropagation();
+                          setPicker(null);
+                          setMenu({ index, position: menuPosition(event.currentTarget) });
+                        }}
+                        onToggleAlwaysRun={() => toggleAlwaysRun(index)}
+                        onToggleStartFrom={() => toggleStartFrom(index)}
+                      />
+                    );
+                  })}
+                </ul>
+  
+                {!hasDirections && <p id="empty-hint" className="hint">Type a command above, or insert a direction below.</p>}
+  
+                <div id="direction-insert-bottom" className="directions-tab-actions">
+                  <button
+                    className="direction-insert-plus direction-insert-plus--bottom"
+                    title="Insert direction"
+                    type="button"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setMenu(null);
+                      setPicker({ anchorIndex: null, position: pickerPosition(event.currentTarget) });
+                    }}
+                  >
+                    + Insert direction
+                  </button>
+                  <button
+                    className="direction-insert-plus direction-insert-plus--bottom"
+                    title="Clear all directions"
+                    type="button"
+                    disabled={!hasDirections}
+                    onClick={() => setClearDirectionsDialogOpen(true)}
+                  >
+                    × Clear directions
+                  </button>
+                </div>
+              </>
+            )}
+  
+            {directionsView === 'json' && (
+              <pre id="steps-json-view">{JSON.stringify(cleanDirections, null, 2)}</pre>
+            )}
           </div>
         </div>
 

--- a/client/DirectionsPanel.jsx
+++ b/client/DirectionsPanel.jsx
@@ -6,6 +6,7 @@ import { DirectionGroup } from './DirectionGroup.jsx';
 import { DirectionMenu } from './DirectionMenu.jsx';
 import { DirectionPicker } from './DirectionPicker.jsx';
 import { PoolStatusIndicators } from './PoolStatusIndicators.jsx';
+import { Dialog } from './Dialog.jsx';
 import { BlueprintPanel } from './Sidebar/BlueprintPanel.jsx';
 import { RecordingSettingsPanel } from './Sidebar/RecordingSettingsPanel.jsx';
 import { directionsForJSON, errorMessage, flattenDirectionActions } from './utils/actions.js';
@@ -39,6 +40,7 @@ export function DirectionsPanel() {
   const {
     alwaysRunIndices,
     cleanDirections,
+    clearDirectionsOnly,
     deleteDirection,
     directions,
     directionsView,
@@ -59,6 +61,7 @@ export function DirectionsPanel() {
   const [menu, setMenu] = useState(null);
   const [picker, setPicker] = useState(null);
   const [activeTab, setActiveTab] = useState('directions');
+  const [clearDirectionsDialogOpen, setClearDirectionsDialogOpen] = useState(false);
   const loadDirection = useDirectionLoader();
   const saveDirectionMutation = useSaveDirectionMutation();
 
@@ -258,6 +261,15 @@ export function DirectionsPanel() {
                 >
                   + Insert direction
                 </button>
+                <button
+                  className="direction-insert-plus direction-insert-plus--bottom"
+                  title="Clear all directions"
+                  type="button"
+                  disabled={!hasDirections}
+                  onClick={() => setClearDirectionsDialogOpen(true)}
+                >
+                  × Clear directions
+                </button>
               </div>
             </>
           )}
@@ -314,6 +326,34 @@ export function DirectionsPanel() {
             onSelect={insertDirection}
           />
         </>
+      )}
+
+      {clearDirectionsDialogOpen && (
+        <Dialog
+          title="Clear directions?"
+          description="Remove all directions from the editor? Recording settings and blueprint will not change. This cannot be undone."
+          onClose={() => setClearDirectionsDialogOpen(false)}
+        >
+          <div className="app-dialog-actions">
+            <button
+              className="app-dialog-btn app-dialog-btn--secondary"
+              type="button"
+              onClick={() => setClearDirectionsDialogOpen(false)}
+            >
+              Cancel
+            </button>
+            <button
+              className="app-dialog-btn app-dialog-btn--danger"
+              type="button"
+              onClick={() => {
+                clearDirectionsOnly();
+                setClearDirectionsDialogOpen(false);
+              }}
+            >
+              Clear directions
+            </button>
+          </div>
+        </Dialog>
       )}
     </div>
   );

--- a/client/Sidebar/BlueprintPanel.jsx
+++ b/client/Sidebar/BlueprintPanel.jsx
@@ -67,7 +67,7 @@ export function BlueprintPanel() {
 
   return (
     <>
-    <div className="tab-panel-body blueprint-body">
+    <div className="tab-panel-body">
       <EnvironmentSection formState={formState} updateForm={updateForm} />
       <SiteSettingsSection formState={formState} updateForm={updateForm} />
       <SlugListSection
@@ -114,32 +114,32 @@ export function BlueprintPanel() {
     </div>
 
     {resetDialogOpen && (
-        <Dialog
-          title="Reset blueprint?"
-          description="Reset all fields to the default blueprint? Your current changes will be lost."
-          closeDisabled={isApplying}
-          onClose={closeResetDialog}
-        >
-          <div className="app-dialog-actions">
-            <button
-              className="app-dialog-btn app-dialog-btn--secondary"
-              type="button"
-              disabled={isApplying}
-              onClick={closeResetDialog}
-            >
-              Cancel
-            </button>
-            <button
-              className="app-dialog-btn app-dialog-btn--danger"
-              type="button"
-              disabled={isApplying}
-              onClick={confirmReset}
-            >
-              {isApplying ? 'Resetting...' : 'Reset'}
-            </button>
-          </div>
-        </Dialog>
-      )}
+      <Dialog
+        title="Reset blueprint?"
+        description="Reset all fields to the default blueprint? Your current changes will be lost."
+        closeDisabled={isApplying}
+        onClose={closeResetDialog}
+      >
+        <div className="app-dialog-actions">
+          <button
+            className="app-dialog-btn app-dialog-btn--secondary"
+            type="button"
+            disabled={isApplying}
+            onClick={closeResetDialog}
+          >
+            Cancel
+          </button>
+          <button
+            className="app-dialog-btn app-dialog-btn--danger"
+            type="button"
+            disabled={isApplying}
+            onClick={confirmReset}
+          >
+            {isApplying ? 'Resetting...' : 'Reset'}
+          </button>
+        </div>
+      </Dialog>
+    )}
     </>
   );
 }

--- a/client/Sidebar/BlueprintPanel.jsx
+++ b/client/Sidebar/BlueprintPanel.jsx
@@ -66,7 +66,8 @@ export function BlueprintPanel() {
   }
 
   return (
-    <div className="blueprint-body blueprint-body--embedded">
+    <>
+    <div className="tab-panel-body blueprint-body">
       <EnvironmentSection formState={formState} updateForm={updateForm} />
       <SiteSettingsSection formState={formState} updateForm={updateForm} />
       <SlugListSection
@@ -91,27 +92,28 @@ export function BlueprintPanel() {
           </pre>
         </details>
       </section>
+    </div>
 
-      <div className="blueprint-panel-actions">
-        <button
-          type="button"
-          className="bp-action-btn bp-action-btn--ghost"
-          onClick={openResetDialog}
-          disabled={!defaultBlueprint || isAtDefault || isApplying}
-        >
-          Reset
-        </button>
-        <button
-          type="button"
-          className={clsx('bp-action-btn bp-action-btn--primary', isApplying && 'is-loading')}
-          onClick={handleApply}
-          disabled={isApplying || !hasUnappliedChanges}
-        >
-          Apply
-        </button>
-      </div>
+    <div className="tab-panel-footer">
+      <button
+        type="button"
+        className="bp-action-btn bp-action-btn--ghost"
+        onClick={openResetDialog}
+        disabled={!defaultBlueprint || isAtDefault || isApplying}
+      >
+        Reset
+      </button>
+      <button
+        type="button"
+        className={clsx('bp-action-btn bp-action-btn--primary', isApplying && 'is-loading')}
+        onClick={handleApply}
+        disabled={isApplying || !hasUnappliedChanges}
+      >
+        Apply
+      </button>
+    </div>
 
-      {resetDialogOpen && (
+    {resetDialogOpen && (
         <Dialog
           title="Reset blueprint?"
           description="Reset all fields to the default blueprint? Your current changes will be lost."
@@ -138,6 +140,6 @@ export function BlueprintPanel() {
           </div>
         </Dialog>
       )}
-    </div>
+    </>
   );
 }

--- a/client/Sidebar/BlueprintPanel.jsx
+++ b/client/Sidebar/BlueprintPanel.jsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import { useState, useMemo } from 'react';
 import { toast } from 'react-toastify';
+import { Dialog } from '../Dialog.jsx';
 import { useAppState } from '../context/AppStateContext.jsx';
 import { blueprintToForm, useBlueprintFormState } from '../state/useBlueprintFormState.js';
 import { errorMessage } from '../utils/actions.js';
@@ -11,11 +12,12 @@ import { SlugListSection } from '../blueprint/SlugListSection.jsx';
 import { ContentSection } from '../blueprint/ContentSection.jsx';
 
 export function BlueprintPanel() {
-  const { blueprint: appBlueprint, defaultBlueprint, setBlueprint } = useAppState();
-  const { formState, updateForm, loadBlueprint, compiledBlueprint } =
+  const { blueprint: appBlueprint, defaultBlueprint, setBlueprint, resetBlueprintToDefault } = useAppState();
+  const { formState, updateForm, compiledBlueprint } =
     useBlueprintFormState(appBlueprint);
 
   const [isApplying, setIsApplying] = useState(false);
+  const [resetDialogOpen, setResetDialogOpen] = useState(false);
 
   // Compare on form-state (not compiled JSON) so incidental key-order / shape
   // differences in the on-disk blueprint don't make the form look "dirty".
@@ -42,15 +44,20 @@ export function BlueprintPanel() {
     }
   }
 
-  async function handleReset() {
+  function openResetDialog() {
     if (!defaultBlueprint) return;
-    if (!window.confirm('Reset all fields to the default blueprint? Your current changes will be lost.')) return;
+    setResetDialogOpen(true);
+  }
+
+  function closeResetDialog() {
+    if (!isApplying) setResetDialogOpen(false);
+  }
+
+  async function confirmReset() {
     setIsApplying(true);
     try {
-      const bp = await api.resetBlueprint();
-      const target = bp ?? defaultBlueprint;
-      loadBlueprint(target);
-      setBlueprint(target);
+      await resetBlueprintToDefault();
+      setResetDialogOpen(false);
     } catch (err) {
       toast.error(errorMessage(err, 'Could not reset blueprint'));
     } finally {
@@ -89,7 +96,7 @@ export function BlueprintPanel() {
         <button
           type="button"
           className="bp-action-btn bp-action-btn--ghost"
-          onClick={handleReset}
+          onClick={openResetDialog}
           disabled={!defaultBlueprint || isAtDefault || isApplying}
         >
           Reset
@@ -103,6 +110,34 @@ export function BlueprintPanel() {
           Apply
         </button>
       </div>
+
+      {resetDialogOpen && (
+        <Dialog
+          title="Reset blueprint?"
+          description="Reset all fields to the default blueprint? Your current changes will be lost."
+          closeDisabled={isApplying}
+          onClose={closeResetDialog}
+        >
+          <div className="app-dialog-actions">
+            <button
+              className="app-dialog-btn app-dialog-btn--secondary"
+              type="button"
+              disabled={isApplying}
+              onClick={closeResetDialog}
+            >
+              Cancel
+            </button>
+            <button
+              className="app-dialog-btn app-dialog-btn--danger"
+              type="button"
+              disabled={isApplying}
+              onClick={confirmReset}
+            >
+              {isApplying ? 'Resetting...' : 'Reset'}
+            </button>
+          </div>
+        </Dialog>
+      )}
     </div>
   );
 }

--- a/client/Sidebar/RecordingSettingsPanel.jsx
+++ b/client/Sidebar/RecordingSettingsPanel.jsx
@@ -1,5 +1,8 @@
 import clsx from 'clsx';
+import { useMemo, useState } from 'react';
+import { Dialog } from '../Dialog.jsx';
 import { useAppState } from '../context/AppStateContext.jsx';
+import { DEFAULT_RUN_SETTINGS } from '../state/useRunSettingsState.js';
 import { VIDEO_SIZE_VALUES } from '../utils/actions.js';
 
 const VIDEO_LABELS = {
@@ -11,6 +14,7 @@ const VIDEO_LABELS = {
 export function RecordingSettingsPanel() {
   const {
     endPause,
+    resetRecordingSettings,
     setEndPause,
     setStepPause,
     setTypingDelay,
@@ -19,6 +23,17 @@ export function RecordingSettingsPanel() {
     typingDelay,
     videoSize,
   } = useAppState();
+  const [resetDialogOpen, setResetDialogOpen] = useState(false);
+
+  const isAtDefault = useMemo(
+    () => (
+      endPause === DEFAULT_RUN_SETTINGS.endPause
+      && stepPause === DEFAULT_RUN_SETTINGS.stepPause
+      && typingDelay === DEFAULT_RUN_SETTINGS.typingDelay
+      && videoSize === DEFAULT_RUN_SETTINGS.videoSize
+    ),
+    [endPause, stepPause, typingDelay, videoSize],
+  );
 
   return (
     <div className="recording-settings-body recording-settings-body--embedded">
@@ -91,6 +106,45 @@ export function RecordingSettingsPanel() {
           onChange={(event) => setEndPause(event.target.value)}
         />
       </div>
+
+      <div className="blueprint-panel-actions">
+        <button
+          type="button"
+          className="bp-action-btn bp-action-btn--ghost"
+          onClick={() => setResetDialogOpen(true)}
+          disabled={isAtDefault}
+        >
+          Reset
+        </button>
+      </div>
+
+      {resetDialogOpen && (
+        <Dialog
+          title="Reset recording settings?"
+          description="Reset typing speed, between-step pause, video size, and outro length to defaults?"
+          onClose={() => setResetDialogOpen(false)}
+        >
+          <div className="app-dialog-actions">
+            <button
+              className="app-dialog-btn app-dialog-btn--secondary"
+              type="button"
+              onClick={() => setResetDialogOpen(false)}
+            >
+              Cancel
+            </button>
+            <button
+              className="app-dialog-btn app-dialog-btn--danger"
+              type="button"
+              onClick={() => {
+                resetRecordingSettings();
+                setResetDialogOpen(false);
+              }}
+            >
+              Reset
+            </button>
+          </div>
+        </Dialog>
+      )}
     </div>
   );
 }

--- a/client/Sidebar/RecordingSettingsPanel.jsx
+++ b/client/Sidebar/RecordingSettingsPanel.jsx
@@ -121,32 +121,32 @@ export function RecordingSettingsPanel() {
     </div>
 
     {resetDialogOpen && (
-        <Dialog
-          title="Reset recording settings?"
-          description="Reset typing speed, between-step pause, video size, and outro length to defaults?"
-          onClose={() => setResetDialogOpen(false)}
-        >
-          <div className="app-dialog-actions">
-            <button
-              className="app-dialog-btn app-dialog-btn--secondary"
-              type="button"
-              onClick={() => setResetDialogOpen(false)}
-            >
-              Cancel
-            </button>
-            <button
-              className="app-dialog-btn app-dialog-btn--danger"
-              type="button"
-              onClick={() => {
-                resetRecordingSettings();
-                setResetDialogOpen(false);
-              }}
-            >
-              Reset
-            </button>
-          </div>
-        </Dialog>
-      )}
+      <Dialog
+        title="Reset recording settings?"
+        description="Reset typing speed, between-step pause, video size, and outro length to defaults?"
+        onClose={() => setResetDialogOpen(false)}
+      >
+        <div className="app-dialog-actions">
+          <button
+            className="app-dialog-btn app-dialog-btn--secondary"
+            type="button"
+            onClick={() => setResetDialogOpen(false)}
+          >
+            Cancel
+          </button>
+          <button
+            className="app-dialog-btn app-dialog-btn--danger"
+            type="button"
+            onClick={() => {
+              resetRecordingSettings();
+              setResetDialogOpen(false);
+            }}
+          >
+            Reset
+          </button>
+        </div>
+      </Dialog>
+    )}
     </>
   );
 }

--- a/client/Sidebar/RecordingSettingsPanel.jsx
+++ b/client/Sidebar/RecordingSettingsPanel.jsx
@@ -36,7 +36,8 @@ export function RecordingSettingsPanel() {
   );
 
   return (
-    <div className="recording-settings-body recording-settings-body--embedded">
+    <>
+    <div className="tab-panel-body">
       <div className="setting-field">
         <div className="setting-field-header">
           <label htmlFor="typing-delay-input">Typing speed</label>
@@ -106,19 +107,20 @@ export function RecordingSettingsPanel() {
           onChange={(event) => setEndPause(event.target.value)}
         />
       </div>
+    </div>
 
-      <div className="blueprint-panel-actions">
-        <button
-          type="button"
-          className="bp-action-btn bp-action-btn--ghost"
-          onClick={() => setResetDialogOpen(true)}
-          disabled={isAtDefault}
-        >
-          Reset
-        </button>
-      </div>
+    <div className="tab-panel-footer">
+      <button
+        type="button"
+        className="bp-action-btn bp-action-btn--ghost"
+        onClick={() => setResetDialogOpen(true)}
+        disabled={isAtDefault}
+      >
+        Reset
+      </button>
+    </div>
 
-      {resetDialogOpen && (
+    {resetDialogOpen && (
         <Dialog
           title="Reset recording settings?"
           description="Reset typing speed, between-step pause, video size, and outro length to defaults?"
@@ -145,6 +147,6 @@ export function RecordingSettingsPanel() {
           </div>
         </Dialog>
       )}
-    </div>
+    </>
   );
 }

--- a/client/context/AppStateContext.jsx
+++ b/client/context/AppStateContext.jsx
@@ -16,6 +16,7 @@ export function AppStateProvider({ children }) {
   } = useDirectionsState();
   const {
     loadScriptSettings,
+    resetRecordingSettings,
     resetScriptSettings,
     ...runSettings
   } = useRunSettingsState();
@@ -47,6 +48,8 @@ export function AppStateProvider({ children }) {
     ...blueprintState,
     ...collections,
     clearDirections,
+    clearDirectionsOnly: clearDirectionState,
+    resetRecordingSettings,
     loadScriptIntoEditor,
     poolStatus,
   };

--- a/client/context/AppStateContext.jsx
+++ b/client/context/AppStateContext.jsx
@@ -20,13 +20,15 @@ export function AppStateProvider({ children }) {
     ...runSettings
   } = useRunSettingsState();
   const blueprintState = useBlueprintState();
+  const { resetBlueprintToDefault } = blueprintState;
   const collections = useServerCollections();
   const poolStatus = usePoolStatus();
 
-  const clearDirections = useCallback(() => {
+  const clearDirections = useCallback(async () => {
     clearDirectionState();
     resetScriptSettings();
-  }, [clearDirectionState, resetScriptSettings]);
+    await resetBlueprintToDefault();
+  }, [clearDirectionState, resetScriptSettings, resetBlueprintToDefault]);
 
   const loadScriptIntoEditor = useCallback(async (script) => {
     if (script.blueprint) {

--- a/client/state/useBlueprintFormState.js
+++ b/client/state/useBlueprintFormState.js
@@ -216,15 +216,9 @@ export function useBlueprintFormState(initialBlueprint) {
     setFormState((prev) => ({ ...prev, ...partial }));
   }
 
-  function loadBlueprint(bp) {
-    schemaRef.current = bp?.$schema ?? null;
-    setFormState(blueprintToForm(bp));
-  }
-
   return {
     formState,
     updateForm,
-    loadBlueprint,
     compiledBlueprint,
     hasExtraSteps: formState.extraSteps.length > 0,
   };

--- a/client/state/useBlueprintState.js
+++ b/client/state/useBlueprintState.js
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
   useCurrentBlueprintQuery,
   useDefaultBlueprintQuery,
 } from '../utils/apiHooks.js';
+import { api } from '../utils/api.js';
 
 export function useBlueprintState() {
   const [blueprintOverride, setBlueprint] = useState();
@@ -15,9 +16,17 @@ export function useBlueprintState() {
     : null;
   const blueprint = blueprintOverride === undefined ? loadedBlueprint : blueprintOverride;
 
+  const resetBlueprintToDefault = useCallback(async () => {
+    const bp = await api.resetBlueprint();
+    const target = bp ?? defaultBlueprint;
+    if (target) setBlueprint(target);
+    return target;
+  }, [defaultBlueprint]);
+
   return {
     blueprint,
     setBlueprint,
     defaultBlueprint,
+    resetBlueprintToDefault,
   };
 }

--- a/client/state/useRunSettingsState.js
+++ b/client/state/useRunSettingsState.js
@@ -39,13 +39,17 @@ export function useRunSettingsState() {
     millisecondsFromValue(typingDelay, Number(DEFAULT_RUN_SETTINGS.typingDelay), 1000)
   ), [typingDelay]);
 
-  const resetScriptSettings = useCallback(() => {
-    setName('');
+  const resetRecordingSettings = useCallback(() => {
     setEndPause(DEFAULT_RUN_SETTINGS.endPause);
     setStepPause(DEFAULT_RUN_SETTINGS.stepPause);
     setTypingDelay(DEFAULT_RUN_SETTINGS.typingDelay);
     setVideoSize(DEFAULT_RUN_SETTINGS.videoSize);
   }, []);
+
+  const resetScriptSettings = useCallback(() => {
+    setName('');
+    resetRecordingSettings();
+  }, [resetRecordingSettings]);
 
   const loadScriptSettings = useCallback((script) => {
     setName(script.name);
@@ -73,6 +77,7 @@ export function useRunSettingsState() {
     videoSize,
     setVideoSize,
     currentVideoSize,
+    resetRecordingSettings,
     resetScriptSettings,
     loadScriptSettings,
   };

--- a/public/style.css
+++ b/public/style.css
@@ -674,6 +674,32 @@ header p {
   color: #fff;
 }
 
+/* ── Shared tab panel frame ─────────────────────────────── */
+
+.tab-panel-body {
+  background: #111827;
+  border-radius: 6px;
+  box-shadow: inset 0 0 0 1px #1e2433;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  max-width: 100%;
+  min-width: 0;
+  padding: 0.9rem 1.25rem;
+}
+
+.tab-panel-footer {
+  align-items: center;
+  background: #111827;
+  border-radius: 6px;
+  box-shadow: inset 0 0 0 1px #1e2433;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  padding: 0.75rem 1.25rem;
+}
+
 /* ── Recording settings section ─────────────────────────── */
 
 .recording-settings-body {
@@ -954,6 +980,13 @@ header p {
 .script-settings-tab-panel {
   max-width: 100%;
   min-width: 0;
+}
+
+.script-settings-tab-panel:not([hidden]) {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-height: 100%;
 }
 
 .script-settings-tab #step-count,

--- a/public/style.css
+++ b/public/style.css
@@ -364,11 +364,11 @@ header p {
   flex-shrink: 0;
 }
 
-.blueprint-body .bfs-collapsible[open] > .bfs-summary::before {
+.bfs-collapsible[open] > .bfs-summary::before {
   transform: rotate(90deg);
 }
 
-.blueprint-body .bfs-collapsible[open] > .bfs-summary {
+.bfs-collapsible[open] > .bfs-summary {
   color: #e2e8f0;
   margin-bottom: 0.75rem;
 }
@@ -960,10 +960,6 @@ header p {
   letter-spacing: 0.08em;
   color: #64748b;
   margin-bottom: 0.75rem;
-}
-
-.directions-view-switcher {
-  background: #111827;
 }
 
 .directions-view-toggle {

--- a/public/style.css
+++ b/public/style.css
@@ -210,47 +210,6 @@ header p {
   cursor: not-allowed;
 }
 
-.blueprint-body {
-  min-width: 0;
-  padding: 0;
-}
-
-.blueprint-body--embedded {
-  background: #111827;
-  border-radius: 6px;
-  box-shadow: inset 0 0 0 1px #1e2433;
-  display: flex;
-  flex-direction: column;
-  max-width: 100%;
-  min-height: 100%;
-  min-width: 0;
-  overflow: clip;
-}
-
-.blueprint-panel-actions {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  justify-content: flex-end;
-  margin-top: 0;
-  padding: 0.75rem 1.25rem 0.75rem 0.75rem;
-  border-top: 1px solid #1e2433;
-  background: #111827;
-}
-
-.blueprint-body--embedded .blueprint-panel-actions {
-  bottom: 0;
-  box-shadow:
-    inset 1px 0 0 #1e2433,
-    inset -1px 0 0 #1e2433,
-    inset 0 -1px 0 #1e2433,
-    0 -10px 18px rgba(3, 7, 18, 0.35);
-  margin-top: auto;
-  position: sticky;
-  z-index: 6;
-}
-
 .blueprint-pool-indicators {
   align-items: center;
   display: flex;
@@ -697,19 +656,6 @@ header p {
 
 /* ── Recording settings section ─────────────────────────── */
 
-.recording-settings-body {
-  display: flex;
-  flex-direction: column;
-  gap: 0.9rem;
-  padding: 0.75rem 1.5rem 1rem;
-}
-
-.recording-settings-body--embedded {
-  background: #111827;
-  border: 1px solid #1e2433;
-  border-radius: 6px;
-}
-
 .setting-field {
   display: flex;
   flex-direction: column;
@@ -879,7 +825,7 @@ header p {
 
 .script-settings-scroll,
 #steps-json-view,
-.blueprint-body--embedded .bfs-json-preview {
+.bfs-json-preview {
   scrollbar-color: #334155 #0b1020;
   scrollbar-gutter: stable;
   scrollbar-width: thin;
@@ -887,21 +833,21 @@ header p {
 
 .script-settings-scroll::-webkit-scrollbar,
 #steps-json-view::-webkit-scrollbar,
-.blueprint-body--embedded .bfs-json-preview::-webkit-scrollbar {
+.bfs-json-preview::-webkit-scrollbar {
   height: 10px;
   width: 10px;
 }
 
 .script-settings-scroll::-webkit-scrollbar-track,
 #steps-json-view::-webkit-scrollbar-track,
-.blueprint-body--embedded .bfs-json-preview::-webkit-scrollbar-track {
+.bfs-json-preview::-webkit-scrollbar-track {
   background: #0b1020;
   border-radius: 999px;
 }
 
 .script-settings-scroll::-webkit-scrollbar-thumb,
 #steps-json-view::-webkit-scrollbar-thumb,
-.blueprint-body--embedded .bfs-json-preview::-webkit-scrollbar-thumb {
+.bfs-json-preview::-webkit-scrollbar-thumb {
   background: #263449;
   border: 2px solid #0b1020;
   border-radius: 999px;
@@ -909,13 +855,13 @@ header p {
 
 .script-settings-scroll::-webkit-scrollbar-thumb:hover,
 #steps-json-view::-webkit-scrollbar-thumb:hover,
-.blueprint-body--embedded .bfs-json-preview::-webkit-scrollbar-thumb:hover {
+.bfs-json-preview::-webkit-scrollbar-thumb:hover {
   background: #3a4b66;
 }
 
 .script-settings-scroll::-webkit-scrollbar-corner,
 #steps-json-view::-webkit-scrollbar-corner,
-.blueprint-body--embedded .bfs-json-preview::-webkit-scrollbar-corner {
+.bfs-json-preview::-webkit-scrollbar-corner {
   background: transparent;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -1017,11 +1017,7 @@ header p {
 }
 
 .directions-view-switcher {
-  background: #0f1117;
-  padding: 0 0 0.5rem;
-  position: sticky;
-  top: 0;
-  z-index: 5;
+  background: #111827;
 }
 
 .directions-view-toggle {
@@ -1936,10 +1932,6 @@ header p {
 .direction-item--builtin .direction-name { color: #94a3b8; }
 
 /* ── Bottom insert button ────────────────────────────────────────────────────── */
-#direction-insert-bottom {
-  padding: 0.5rem 0 0.25rem;
-}
-
 .directions-tab-actions {
   align-items: center;
   display: flex;

--- a/public/style.css
+++ b/public/style.css
@@ -440,13 +440,8 @@ header p {
 }
 
 .blueprint-form-section {
-  border-top: 1px solid #1e2433;
-  background: #0d1120;
   min-width: 0;
-  padding: 0.5rem 0;
 }
-
-.blueprint-form-section:first-of-type { border-top: none; }
 
 /* ── Blueprint form fields ───────────────────────────────── */
 


### PR DESCRIPTION
## Summary
- Toolbar **Clear** now resets directions, recording settings, and the blueprint together (gated by a `Dialog` confirm).
- **Directions** tab gets its own Clear button (styled to match Insert direction, right-aligned in the bottom action row) that wipes only the directions list.
- **Recording Settings** tab gets a Reset button that restores its four sliders to defaults without touching the script name.
- Blueprint reset logic consolidated into a shared `resetBlueprintToDefault` on `useBlueprintState`, used by both the toolbar Clear and the Blueprint panel Reset.
- Blueprint panel Reset switched from `window.confirm` to the shared `Dialog` for UX consistency. No `window.confirm` calls remain.

### Tab panel UI alignment
- Introduced shared `.tab-panel-body` / `.tab-panel-footer` CSS primitives so the Directions, Blueprint, and Recording Settings tabs share a single card chrome (background, inset border, radius, padding, gap).
- **Recording Settings** and **Blueprint** now render as a body card followed by a separate footer card (Reset / Reset+Apply), instead of a sticky footer bar inside the same container.
- Stripped Blueprint's per-section background and divider lines; spacing now comes from the body's gap so accordion sections sit flat inside the chrome.
- **Directions** tabpanel wrapped in the shared body; dropped the view-switcher's sticky positioning and legacy padding now that the body handles layout.
- Cleanup pass removed dead `.blueprint-body--embedded`, `.blueprint-panel-actions`, `.recording-settings-body*`, and `.directions-view-switcher` rules, dropped the no-longer-needed `.blueprint-body` className, and re-indented JSX after the Fragment wrappers.

Closes: [DEVREL-1408](https://linear.app/a8c/issue/DEVREL-1408), [DEVREL-1410](https://linear.app/a8c/issue/DEVREL-1410)

## Test plan
- [ ] Load a saved script with custom blueprint + settings. Click toolbar Clear → confirm. Directions empty, name cleared, settings back to defaults, blueprint shows default (Reset button disabled).
- [ ] On Directions tab with directions present, click Clear → confirm. Only directions clear; settings and blueprint untouched.
- [ ] On Recording Settings tab with non-default values, click Reset → confirm. Only the four sliders reset; script name and directions untouched.
- [ ] On Blueprint tab with edits, click Reset → confirm. Blueprint resets via the shared Dialog.
- [ ] Each Cancel button dismisses its dialog without changes.
- [ ] Switch between Directions, Blueprint, and Recording Settings tabs — outer padding, card chrome, and Reset card placement read as consistent across all three.
- [ ] Blueprint accordion sections sit flush inside the body card without per-section dividers.
- [ ] Directions Actions/JSON toggle no longer sticks to the top while scrolling; spacing inside the directions card matches the other tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)