### PR TITLE
DEVREL-1388: WordPress.org plugin lookup in Blueprint UI

### DIFF
--- a/client/Sidebar/BlueprintPanel.jsx
+++ b/client/Sidebar/BlueprintPanel.jsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { useState, useMemo } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { toast } from 'react-toastify';
 import { useAppState } from '../context/AppStateContext.jsx';
 import { blueprintToForm, useBlueprintFormState } from '../state/useBlueprintFormState.js';
@@ -16,6 +16,40 @@ export function BlueprintPanel() {
     useBlueprintFormState(appBlueprint);
 
   const [isApplying, setIsApplying] = useState(false);
+  const [pluginNames, setPluginNames] = useState({});
+
+  // Resolve display names for any plugin slug we haven't seen yet. Fires on
+  // initial load and whenever the plugins list grows by a free-form slug.
+  // Server caches WP.org lookups for 5 min, so reloads are cheap.
+  useEffect(() => {
+    const missing = formState.plugins
+      .map((p) => p.slug)
+      .filter((slug) => slug && !pluginNames[slug]);
+    if (missing.length === 0) return undefined;
+
+    let cancelled = false;
+    Promise.all(
+      missing.map(async (slug) => {
+        try {
+          const info = await api.getPluginInfo(slug);
+          return [slug, info?.name || null];
+        } catch {
+          return [slug, null];
+        }
+      }),
+    ).then((pairs) => {
+      if (cancelled) return;
+      const patch = {};
+      for (const [slug, name] of pairs) if (name) patch[slug] = name;
+      if (Object.keys(patch).length > 0) {
+        setPluginNames((prev) => ({ ...prev, ...patch }));
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [formState.plugins, pluginNames]);
 
   // Compare on form-state (not compiled JSON) so incidental key-order / shape
   // differences in the on-disk blueprint don't make the form look "dirty".
@@ -66,7 +100,10 @@ export function BlueprintPanel() {
         title="Plugins" sectionId="section-plugins"
         items={formState.plugins} onUpdate={(plugins) => updateForm({ plugins })}
         itemType="plugin" inputId="bf-plugin-slug"
-        inputPlaceholder="WordPress.org plugin slug"
+        inputPlaceholder="Search WordPress.org or enter a slug"
+        onSearch={(q, opts) => api.searchPlugins(q, opts)}
+        nameMap={pluginNames}
+        onLearnName={(slug, name) => setPluginNames((prev) => ({ ...prev, [slug]: name }))}
       />
       <SlugListSection
         title="Themes" sectionId="section-themes"

--- a/client/blueprint/PluginSearchSuggestions.jsx
+++ b/client/blueprint/PluginSearchSuggestions.jsx
@@ -1,0 +1,68 @@
+import clsx from 'clsx';
+
+export function PluginSearchSuggestions({
+  query,
+  results,
+  loading,
+  error,
+  existingSlugs,
+  activeIndex,
+  listId,
+  onSelect,
+  onHoverIndex,
+}) {
+  if (!query) return null;
+
+  const showEmpty = !loading && !error && results.length === 0;
+
+  return (
+    <div className="bf-suggestions" id={listId} role="listbox">
+      {loading && <div className="bf-suggestions-status">Searching WordPress.org…</div>}
+      {error && (
+        <div className="bf-suggestions-status bf-suggestions-error">
+          Couldn't reach WordPress.org — {error}
+        </div>
+      )}
+      {showEmpty && (
+        <div className="bf-suggestions-status">No plugins found for "{query}"</div>
+      )}
+      {results.map((r, i) => {
+        const isAdded = existingSlugs.has(r.slug);
+        return (
+          <button
+            type="button"
+            key={r.slug}
+            role="option"
+            aria-selected={i === activeIndex}
+            disabled={isAdded}
+            className={clsx(
+              'bf-suggestion',
+              i === activeIndex && 'is-active',
+              isAdded && 'is-added',
+            )}
+            onMouseEnter={() => onHoverIndex(i)}
+            onMouseDown={(e) => {
+              // Prevent input blur before click registers.
+              e.preventDefault();
+              if (!isAdded) onSelect(r);
+            }}
+          >
+            {r.icon ? (
+              <img src={r.icon} alt="" className="bf-suggestion-icon" />
+            ) : (
+              <span className="bf-suggestion-icon bf-suggestion-icon--placeholder" aria-hidden="true" />
+            )}
+            <span className="bf-suggestion-body">
+              <span className="bf-suggestion-name">{r.name}</span>
+              {r.author && <span className="bf-suggestion-meta">by {r.author}</span>}
+              {r.shortDescription && (
+                <span className="bf-suggestion-desc">{r.shortDescription}</span>
+              )}
+            </span>
+            {isAdded && <span className="bf-suggestion-added">Added</span>}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/client/blueprint/PluginSearchSuggestions.jsx
+++ b/client/blueprint/PluginSearchSuggestions.jsx
@@ -8,16 +8,26 @@ export function PluginSearchSuggestions({
   existingSlugs,
   activeIndex,
   listId,
+  hasMore,
   onSelect,
   onHoverIndex,
+  onLoadMore,
 }) {
   if (!query) return null;
 
-  const showEmpty = !loading && !error && results.length === 0;
+  const hasResults = results.length > 0;
+  const showInitialLoading = loading && !hasResults;
+  const showEmpty = !loading && !error && !hasResults;
+  const showInlineLoading = loading && hasResults;
 
   return (
     <div className="bf-suggestions" id={listId} role="listbox">
-      {loading && <div className="bf-suggestions-status">Searching WordPress.org…</div>}
+      {showInitialLoading && (
+        <div className="bf-suggestions-status">
+          <span className="bf-spinner" aria-hidden="true" />
+          Searching WordPress.org…
+        </div>
+      )}
       {error && (
         <div className="bf-suggestions-status bf-suggestions-error">
           Couldn't reach WordPress.org — {error}
@@ -42,7 +52,6 @@ export function PluginSearchSuggestions({
             )}
             onMouseEnter={() => onHoverIndex(i)}
             onMouseDown={(e) => {
-              // Prevent input blur before click registers.
               e.preventDefault();
               if (!isAdded) onSelect(r);
             }}
@@ -63,6 +72,24 @@ export function PluginSearchSuggestions({
           </button>
         );
       })}
+      {hasMore && !showInlineLoading && (
+        <button
+          type="button"
+          className="bf-suggestions-more"
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onLoadMore?.();
+          }}
+        >
+          Show more
+        </button>
+      )}
+      {showInlineLoading && (
+        <div className="bf-suggestions-status bf-suggestions-status--inline">
+          <span className="bf-spinner" aria-hidden="true" />
+          Loading…
+        </div>
+      )}
     </div>
   );
 }

--- a/client/blueprint/SlugListSection.jsx
+++ b/client/blueprint/SlugListSection.jsx
@@ -1,18 +1,96 @@
 import clsx from 'clsx';
-import { useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { PluginSearchSuggestions } from './PluginSearchSuggestions.jsx';
 
-export function SlugListSection({ title, sectionId, items, onUpdate, itemType, inputId, inputPlaceholder }) {
+const SEARCH_DEBOUNCE_MS = 250;
+
+export function SlugListSection({
+  title,
+  sectionId,
+  items,
+  onUpdate,
+  itemType,
+  inputId,
+  inputPlaceholder,
+  onSearch,
+  nameMap,
+  onLearnName,
+}) {
   const [slugInput, setSlugInput] = useState('');
+  const [searchState, setSearchState] = useState({
+    results: [],
+    loading: false,
+    error: null,
+    query: '',
+  });
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const [isFocused, setIsFocused] = useState(false);
+  const abortRef = useRef(null);
+  const debounceRef = useRef(null);
+  const blurTimeoutRef = useRef(null);
+  const inputRef = useRef(null);
+  const [dropdownCoords, setDropdownCoords] = useState(null);
 
   const slugTrimmed = slugInput.trim();
   const isDuplicate = items.some((item) => item.slug === slugTrimmed);
   const canAdd = slugTrimmed.length > 0 && !isDuplicate;
   const dupWarnId = `${inputId}-dup-warn`;
+  const listId = `${inputId}-suggestions`;
+  const existingSlugs = useMemo(() => new Set(items.map((i) => i.slug)), [items]);
 
-  function addItem() {
-    if (!canAdd) return;
-    onUpdate([...items, { slug: slugTrimmed }]);
+  useEffect(() => {
+    if (!onSearch) return undefined;
+    if (!slugTrimmed) {
+      setSearchState({ results: [], loading: false, error: null, query: '' });
+      setActiveIndex(-1);
+      return undefined;
+    }
+
+    clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      if (abortRef.current) abortRef.current.abort();
+      const ctrl = new AbortController();
+      abortRef.current = ctrl;
+      setSearchState((s) => ({ ...s, loading: true, error: null }));
+      try {
+        const data = await onSearch(slugTrimmed, { signal: ctrl.signal });
+        if (ctrl.signal.aborted) return;
+        setSearchState({
+          results: Array.isArray(data?.results) ? data.results : [],
+          loading: false,
+          error: null,
+          query: slugTrimmed,
+        });
+        setActiveIndex(-1);
+      } catch (err) {
+        if (err.name === 'AbortError' || ctrl.signal.aborted) return;
+        setSearchState({ results: [], loading: false, error: err.message || 'search failed', query: slugTrimmed });
+      }
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => clearTimeout(debounceRef.current);
+  }, [slugTrimmed, onSearch]);
+
+  useEffect(() => () => {
+    clearTimeout(debounceRef.current);
+    clearTimeout(blurTimeoutRef.current);
+    if (abortRef.current) abortRef.current.abort();
+  }, []);
+
+  function addSlug(slug, name) {
+    const cleaned = slug.trim();
+    if (!cleaned || existingSlugs.has(cleaned)) return;
+    if (name && onLearnName) onLearnName(cleaned, name);
+    onUpdate([...items, { slug: cleaned }]);
     setSlugInput('');
+    setSearchState({ results: [], loading: false, error: null, query: '' });
+    setActiveIndex(-1);
+  }
+
+  function addFromInput() {
+    if (!canAdd) return;
+    addSlug(slugTrimmed, null);
   }
 
   function removeItem(index) {
@@ -20,8 +98,76 @@ export function SlugListSection({ title, sectionId, items, onUpdate, itemType, i
   }
 
   function handleKeyDown(e) {
-    if (e.key === 'Enter') addItem();
+    const hasSuggestions = onSearch && searchState.results.length > 0;
+    if (hasSuggestions) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActiveIndex((i) => Math.min(i + 1, searchState.results.length - 1));
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActiveIndex((i) => Math.max(i - 1, -1));
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setSearchState({ results: [], loading: false, error: null, query: '' });
+        setActiveIndex(-1);
+        return;
+      }
+      if (e.key === 'Enter' && activeIndex >= 0) {
+        e.preventDefault();
+        const r = searchState.results[activeIndex];
+        if (r) addSlug(r.slug, r.name);
+        return;
+      }
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      addFromInput();
+    }
   }
+
+  function handleBlur() {
+    // Delay so suggestion onMouseDown click can register before the dropdown
+    // hides on blur.
+    clearTimeout(blurTimeoutRef.current);
+    blurTimeoutRef.current = setTimeout(() => setIsFocused(false), 120);
+  }
+
+  function handleFocus() {
+    clearTimeout(blurTimeoutRef.current);
+    setIsFocused(true);
+  }
+
+  const showSuggestions =
+    onSearch &&
+    isFocused &&
+    slugTrimmed.length > 0 &&
+    (searchState.loading ||
+      searchState.error ||
+      searchState.results.length > 0 ||
+      searchState.query === slugTrimmed);
+
+  useLayoutEffect(() => {
+    if (!showSuggestions || !inputRef.current) {
+      setDropdownCoords(null);
+      return undefined;
+    }
+    const update = () => {
+      if (!inputRef.current) return;
+      const r = inputRef.current.getBoundingClientRect();
+      setDropdownCoords({ top: r.bottom + 4, left: r.left, width: r.width });
+    };
+    update();
+    window.addEventListener('scroll', update, true);
+    window.addEventListener('resize', update);
+    return () => {
+      window.removeEventListener('scroll', update, true);
+      window.removeEventListener('resize', update);
+    };
+  }, [showSuggestions]);
 
   return (
     <section className="blueprint-form-section">
@@ -29,21 +175,54 @@ export function SlugListSection({ title, sectionId, items, onUpdate, itemType, i
       <summary className="bfs-summary" id={sectionId}>{title}</summary>
       <div className="bf-fields">
         <div className="bf-slug-row">
-          <input
-            id={inputId}
-            type="text"
-            className={clsx('bf-input', isDuplicate && slugTrimmed && 'bf-input-warn')}
-            value={slugInput}
-            onChange={(e) => setSlugInput(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={inputPlaceholder}
-            aria-label={`${title.slice(0, -1)} slug`}
-            aria-describedby={isDuplicate && slugTrimmed ? dupWarnId : undefined}
-          />
+          <div className="bf-slug-input-wrap">
+            <input
+              ref={inputRef}
+              id={inputId}
+              type="text"
+              className={clsx('bf-input', isDuplicate && slugTrimmed && 'bf-input-warn')}
+              value={slugInput}
+              onChange={(e) => setSlugInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              onFocus={handleFocus}
+              onBlur={handleBlur}
+              placeholder={inputPlaceholder}
+              aria-label={`${title.slice(0, -1)} slug`}
+              aria-describedby={isDuplicate && slugTrimmed ? dupWarnId : undefined}
+              aria-autocomplete={onSearch ? 'list' : undefined}
+              aria-controls={onSearch ? listId : undefined}
+              aria-expanded={onSearch ? showSuggestions : undefined}
+              autoComplete="off"
+            />
+            {showSuggestions && dropdownCoords && createPortal(
+              <div
+                className="bf-suggestions-portal"
+                style={{
+                  position: 'fixed',
+                  top: dropdownCoords.top,
+                  left: dropdownCoords.left,
+                  width: dropdownCoords.width,
+                }}
+              >
+                <PluginSearchSuggestions
+                  query={slugTrimmed}
+                  results={searchState.results}
+                  loading={searchState.loading}
+                  error={searchState.error}
+                  existingSlugs={existingSlugs}
+                  activeIndex={activeIndex}
+                  listId={listId}
+                  onSelect={(r) => addSlug(r.slug, r.name)}
+                  onHoverIndex={setActiveIndex}
+                />
+              </div>,
+              document.body,
+            )}
+          </div>
           <button
             type="button"
             className="bf-add-btn"
-            onClick={addItem}
+            onClick={addFromInput}
             disabled={!canAdd}
             aria-label={`Add ${itemType}`}
           >
@@ -59,19 +238,24 @@ export function SlugListSection({ title, sectionId, items, onUpdate, itemType, i
 
         {items.length > 0 && (
           <ul className="bf-item-list" aria-label={`${title} list`}>
-            {items.map((item, index) => (
-              <li key={item.slug} className="bf-item">
-                <span className="bf-item-slug">{item.slug}</span>
-                <button
-                  type="button"
-                  className="bf-remove-btn"
-                  onClick={() => removeItem(index)}
-                  aria-label={`Remove ${itemType} ${item.slug}`}
-                >
-                  Remove
-                </button>
-              </li>
-            ))}
+            {items.map((item, index) => {
+              const displayName = (nameMap && nameMap[item.slug]) || item.slug;
+              return (
+                <li key={item.slug} className="bf-item">
+                  <span className="bf-item-label">
+                    <span className="bf-item-primary">{displayName}</span>
+                  </span>
+                  <button
+                    type="button"
+                    className="bf-remove-btn"
+                    onClick={() => removeItem(index)}
+                    aria-label={`Remove ${itemType} ${item.slug}`}
+                  >
+                    Remove
+                  </button>
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>

--- a/client/blueprint/SlugListSection.jsx
+++ b/client/blueprint/SlugListSection.jsx
@@ -23,6 +23,8 @@ export function SlugListSection({
     loading: false,
     error: null,
     query: '',
+    page: 1,
+    pages: 1,
   });
   const [activeIndex, setActiveIndex] = useState(-1);
   const [isFocused, setIsFocused] = useState(false);
@@ -42,7 +44,7 @@ export function SlugListSection({
   useEffect(() => {
     if (!onSearch) return undefined;
     if (!slugTrimmed) {
-      setSearchState({ results: [], loading: false, error: null, query: '' });
+      setSearchState({ results: [], loading: false, error: null, query: '', page: 1, pages: 1 });
       setActiveIndex(-1);
       return undefined;
     }
@@ -54,23 +56,60 @@ export function SlugListSection({
       abortRef.current = ctrl;
       setSearchState((s) => ({ ...s, loading: true, error: null }));
       try {
-        const data = await onSearch(slugTrimmed, { signal: ctrl.signal });
+        const data = await onSearch(slugTrimmed, { page: 1, signal: ctrl.signal });
         if (ctrl.signal.aborted) return;
         setSearchState({
           results: Array.isArray(data?.results) ? data.results : [],
           loading: false,
           error: null,
           query: slugTrimmed,
+          page: data?.page || 1,
+          pages: data?.pages || 1,
         });
         setActiveIndex(-1);
       } catch (err) {
         if (err.name === 'AbortError' || ctrl.signal.aborted) return;
-        setSearchState({ results: [], loading: false, error: err.message || 'search failed', query: slugTrimmed });
+        setSearchState({
+          results: [],
+          loading: false,
+          error: err.message || 'search failed',
+          query: slugTrimmed,
+          page: 1,
+          pages: 1,
+        });
       }
     }, SEARCH_DEBOUNCE_MS);
 
     return () => clearTimeout(debounceRef.current);
   }, [slugTrimmed, onSearch]);
+
+  async function loadMore() {
+    if (!onSearch) return;
+    if (searchState.loading) return;
+    if (searchState.page >= searchState.pages) return;
+    if (!searchState.query) return;
+
+    const nextPage = searchState.page + 1;
+    if (abortRef.current) abortRef.current.abort();
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+    setSearchState((s) => ({ ...s, loading: true, error: null }));
+    try {
+      const data = await onSearch(searchState.query, { page: nextPage, signal: ctrl.signal });
+      if (ctrl.signal.aborted) return;
+      const more = Array.isArray(data?.results) ? data.results : [];
+      setSearchState((s) => ({
+        ...s,
+        results: [...s.results, ...more],
+        loading: false,
+        page: data?.page || nextPage,
+        pages: data?.pages || s.pages,
+      }));
+    } catch (err) {
+      if (err.name === 'AbortError' || ctrl.signal.aborted) return;
+      setSearchState((s) => ({ ...s, loading: false, error: err.message || 'failed to load more' }));
+    }
+  }
 
   useEffect(() => () => {
     clearTimeout(debounceRef.current);
@@ -84,7 +123,7 @@ export function SlugListSection({
     if (name && onLearnName) onLearnName(cleaned, name);
     onUpdate([...items, { slug: cleaned }]);
     setSlugInput('');
-    setSearchState({ results: [], loading: false, error: null, query: '' });
+    setSearchState({ results: [], loading: false, error: null, query: '', page: 1, pages: 1 });
     setActiveIndex(-1);
   }
 
@@ -212,6 +251,8 @@ export function SlugListSection({
                   existingSlugs={existingSlugs}
                   activeIndex={activeIndex}
                   listId={listId}
+                  hasMore={searchState.page < searchState.pages}
+                  onLoadMore={loadMore}
                   onSelect={(r) => addSlug(r.slug, r.name)}
                   onHoverIndex={setActiveIndex}
                 />

--- a/client/utils/api.js
+++ b/client/utils/api.js
@@ -143,6 +143,17 @@ export const api = {
     return requestJSON("/api/translate", postOptions({ command, history }));
   },
 
+  async getPluginInfo(slug, { signal } = {}) {
+    const params = new URLSearchParams({ slug });
+    return requestJSON(`/api/plugins/info?${params.toString()}`, { signal });
+  },
+
+  async searchPlugins(q, { page = 1, signal } = {}) {
+    const params = new URLSearchParams({ q });
+    if (page !== 1) params.set("page", String(page));
+    return requestJSON(`/api/plugins/search?${params.toString()}`, { signal });
+  },
+
   startRun(endpoint, body, signal) {
     return apiRequest(endpoint, postOptions(body, { signal }));
   },

--- a/public/style.css
+++ b/public/style.css
@@ -647,16 +647,6 @@ header p {
   padding: 0.5rem 0.75rem;
 }
 
-.bf-item-slug {
-  flex: 1;
-  font-size: 0.875rem;
-  color: #e2e8f0;
-  font-family: monospace;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .bf-remove-btn {
   padding: 0.25rem 0.6rem;
   background: transparent;
@@ -672,6 +662,141 @@ header p {
 .bf-remove-btn:hover {
   background: #f87171;
   color: #fff;
+}
+
+.bf-item-label {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.bf-item-primary {
+  font-size: 0.875rem;
+  color: #e2e8f0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bf-item-secondary {
+  font-size: 0.75rem;
+  color: #94a3b8;
+  font-family: monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Plugin search suggestions dropdown ─────────────────── */
+
+.bf-slug-input-wrap {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+.bf-slug-input-wrap .bf-input { width: 100%; }
+
+.bf-suggestions-portal { z-index: 1000; }
+
+.bf-suggestions {
+  background: #0f172a;
+  border: 1px solid #2d3748;
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+  max-height: 320px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.bf-suggestions-status {
+  padding: 0.6rem 0.75rem;
+  font-size: 0.82rem;
+  color: #94a3b8;
+}
+
+.bf-suggestions-error { color: #f87171; }
+
+.bf-suggestion {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.55rem 0.75rem;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid #1e2433;
+  text-align: left;
+  cursor: pointer;
+  color: #e2e8f0;
+  transition: background 0.1s;
+}
+
+.bf-suggestion:last-child { border-bottom: none; }
+
+.bf-suggestion.is-active,
+.bf-suggestion:hover:not(:disabled) {
+  background: #1a2035;
+}
+
+.bf-suggestion.is-added {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.bf-suggestion-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 4px;
+  flex-shrink: 0;
+  object-fit: cover;
+  background: #1a2035;
+}
+
+.bf-suggestion-icon--placeholder {
+  display: inline-block;
+  border: 1px solid #2d3748;
+}
+
+.bf-suggestion-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.bf-suggestion-name {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #e2e8f0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bf-suggestion-meta {
+  font-size: 0.72rem;
+  color: #94a3b8;
+}
+
+.bf-suggestion-desc {
+  font-size: 0.78rem;
+  color: #cbd5e1;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.bf-suggestion-added {
+  font-size: 0.7rem;
+  color: #94a3b8;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  flex-shrink: 0;
+  align-self: center;
 }
 
 /* ── Recording settings section ─────────────────────────── */

--- a/public/style.css
+++ b/public/style.css
@@ -715,9 +715,48 @@ header p {
   padding: 0.6rem 0.75rem;
   font-size: 0.82rem;
   color: #94a3b8;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.bf-suggestions-status--inline {
+  border-top: 1px solid #1e2433;
+  justify-content: center;
 }
 
 .bf-suggestions-error { color: #f87171; }
+
+.bf-spinner {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid #2d3748;
+  border-top-color: #94a3b8;
+  animation: bf-spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes bf-spin {
+  to { transform: rotate(360deg); }
+}
+
+.bf-suggestions-more {
+  display: block;
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  background: transparent;
+  color: #93c5fd;
+  border: none;
+  border-top: 1px solid #1e2433;
+  font-size: 0.82rem;
+  font-weight: 500;
+  text-align: center;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.bf-suggestions-more:hover { background: #1a2035; }
 
 .bf-suggestion {
   display: flex;

--- a/server.js
+++ b/server.js
@@ -39,6 +39,7 @@ require('./server/routes/scripts').register(app);
 require('./server/routes/directions').register(app);
 require('./server/routes/runner').register(app);
 require('./server/routes/recordings').register(app);
+require('./server/routes/plugins').register(app);
 
 const PORT = process.env.PORT || DEFAULT_SERVER_PORT;
 

--- a/server/routes/plugins.js
+++ b/server/routes/plugins.js
@@ -39,9 +39,28 @@ function cacheSet(key, value) {
   cache.set(key, { t: Date.now(), v: value });
 }
 
+const NAMED_ENTITIES = {
+  amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ',
+  hellip: '…', mdash: '—', ndash: '–',
+  lsquo: '‘', rsquo: '’', ldquo: '“', rdquo: '”',
+  laquo: '«', raquo: '»', copy: '©', reg: '®', trade: '™',
+};
+
+function decodeEntities(s) {
+  return s.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (match, code) => {
+    if (code[0] === '#') {
+      const hex = code[1] === 'x' || code[1] === 'X';
+      const n = parseInt(code.slice(hex ? 2 : 1), hex ? 16 : 10);
+      return Number.isFinite(n) ? String.fromCodePoint(n) : match;
+    }
+    const v = NAMED_ENTITIES[code.toLowerCase()];
+    return v != null ? v : match;
+  });
+}
+
 function stripHtml(s) {
   if (typeof s !== 'string') return '';
-  return s.replace(/<[^>]*>/g, '').trim();
+  return decodeEntities(s.replace(/<[^>]*>/g, '')).trim();
 }
 
 function pickIcon(icons) {
@@ -69,6 +88,48 @@ function normalize(upstream) {
 }
 
 function register(app) {
+  app.get('/api/plugins/info', async (req, res) => {
+    const slug = typeof req.query.slug === 'string' ? req.query.slug.trim() : '';
+    if (!slug) return res.status(400).json({ error: 'slug is required' });
+    if (slug.length > MAX_QUERY_LEN || !/^[a-z0-9._-]+$/i.test(slug)) {
+      return res.status(400).json({ error: 'invalid slug' });
+    }
+
+    const cacheKey = `info|${slug}`;
+    const cached = cacheGet(cacheKey);
+    if (cached) {
+      res.set('X-Cache', 'HIT');
+      return res.json(cached);
+    }
+
+    const params = new URLSearchParams({ action: 'plugin_information', slug });
+    params.append('fields[]', 'icons');
+    const url = `https://api.wordpress.org/plugins/info/1.2/?${params.toString()}`;
+
+    try {
+      const upstream = await fetch(url);
+      if (!upstream.ok) {
+        return res.status(502).json({ error: `Upstream returned ${upstream.status}` });
+      }
+      const json = await upstream.json();
+      if (!json || typeof json !== 'object' || json.error || !json.slug) {
+        return res.status(404).json({ error: 'plugin not found' });
+      }
+      const normalized = {
+        slug: json.slug,
+        name: stripHtml(json.name),
+        author: stripHtml(json.author),
+        icon: pickIcon(json.icons),
+      };
+      cacheSet(cacheKey, normalized);
+      res.set('X-Cache', 'MISS');
+      res.json(normalized);
+    } catch (err) {
+      console.error('[plugins/info] fetch failed:', err.message);
+      res.status(502).json({ error: 'Failed to reach WordPress.org' });
+    }
+  });
+
   app.get('/api/plugins/search', async (req, res) => {
     const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
     const page = Math.max(1, parseInt(String(req.query.page || '1'), 10) || 1);

--- a/server/routes/plugins.js
+++ b/server/routes/plugins.js
@@ -1,0 +1,117 @@
+// @ts-check
+
+/**
+ * WordPress.org plugin directory search proxy.
+ *
+ *   GET /api/plugins/search?q=<term>&page=<n>
+ *
+ * Proxies api.wordpress.org's keyless query_plugins endpoint, trims the
+ * response to just what the UI needs, and caches results in memory for 5
+ * minutes. The proxy isolates the UI from CORS / endpoint changes and lets
+ * us normalize errors in one place.
+ */
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const CACHE_MAX = 100;
+const PER_PAGE = 10;
+const MAX_QUERY_LEN = 100;
+
+const cache = new Map();
+
+function cacheGet(key) {
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.t > CACHE_TTL_MS) {
+    cache.delete(key);
+    return null;
+  }
+  // Refresh LRU position.
+  cache.delete(key);
+  cache.set(key, entry);
+  return entry.v;
+}
+
+function cacheSet(key, value) {
+  if (cache.size >= CACHE_MAX) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  cache.set(key, { t: Date.now(), v: value });
+}
+
+function stripHtml(s) {
+  if (typeof s !== 'string') return '';
+  return s.replace(/<[^>]*>/g, '').trim();
+}
+
+function pickIcon(icons) {
+  if (!icons || typeof icons !== 'object') return null;
+  return icons['1x'] || icons.default || icons.svg || icons['2x'] || null;
+}
+
+function normalize(upstream) {
+  const info = upstream && upstream.info ? upstream.info : {};
+  const plugins = Array.isArray(upstream && upstream.plugins) ? upstream.plugins : [];
+  return {
+    page: info.page || 1,
+    pages: info.pages || 1,
+    results: plugins.map((p) => ({
+      slug: p.slug,
+      name: stripHtml(p.name),
+      author: stripHtml(p.author),
+      version: p.version,
+      shortDescription: stripHtml(p.short_description),
+      icon: pickIcon(p.icons),
+      activeInstalls: p.active_installs,
+      rating: p.rating,
+    })),
+  };
+}
+
+function register(app) {
+  app.get('/api/plugins/search', async (req, res) => {
+    const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+    const page = Math.max(1, parseInt(String(req.query.page || '1'), 10) || 1);
+
+    if (!q) return res.status(400).json({ error: 'q is required' });
+    if (q.length > MAX_QUERY_LEN) {
+      return res.status(400).json({ error: `q too long (max ${MAX_QUERY_LEN})` });
+    }
+
+    const cacheKey = `${q}|${page}`;
+    const cached = cacheGet(cacheKey);
+    if (cached) {
+      res.set('X-Cache', 'HIT');
+      return res.json(cached);
+    }
+
+    const params = new URLSearchParams({
+      action: 'query_plugins',
+      search: q,
+      per_page: String(PER_PAGE),
+      page: String(page),
+    });
+    for (const f of ['short_description', 'icons', 'rating', 'active_installs']) {
+      params.append('fields[]', f);
+    }
+    const url = `https://api.wordpress.org/plugins/info/1.2/?${params.toString()}`;
+
+    try {
+      const upstream = await fetch(url);
+      if (!upstream.ok) {
+        console.error(`[plugins/search] upstream ${upstream.status} for q=${q}`);
+        return res.status(502).json({ error: `Upstream returned ${upstream.status}` });
+      }
+      const json = await upstream.json();
+      const normalized = normalize(json);
+      cacheSet(cacheKey, normalized);
+      res.set('X-Cache', 'MISS');
+      res.json(normalized);
+    } catch (err) {
+      console.error('[plugins/search] fetch failed:', err.message);
+      res.status(502).json({ error: 'Failed to reach WordPress.org' });
+    }
+  });
+}
+
+module.exports = { register };


### PR DESCRIPTION
## Summary

Adds a WordPress.org plugin search affordance to the plugins section of the Blueprint panel so users no longer need to know exact slugs.

- New `GET /api/plugins/search` and `GET /api/plugins/info` proxy endpoints with a 5-min in-memory LRU cache (insulates the UI from WP.org CORS / endpoint changes; entities + HTML in author/name are normalized server-side).
- Plugins input now triggers a debounced search (250 ms) with an abortable in-flight request. Results render in a portaled dropdown (icon, name, author, short description). Keyboard nav (↑/↓/Enter/Esc), spinner during fetch, "Show more" pagination, "Added" badge on slugs already in the list, free-form Enter-to-add preserved for power users.
- Plugins are displayed by **name**; only the slug is emitted into the generated blueprint JSON. Names are re-resolved on reload via `/api/plugins/info` (cached) so the friendly name persists across blueprint reloads without leaking UI-only metadata into the blueprint file.
- Themes section is unchanged — `SlugListSection` only renders the search dropdown when an `onSearch` prop is provided.

Linear: https://linear.app/a8c/issue/DEVREL-1388/plugin-and-theme-lookup-in-the-blueprint-ui

## Test plan

- [ ] `npm start`, open the Blueprint panel, expand Plugins
- [ ] Type "seo" — verify spinner, then a dropdown of WP.org results with icons/names/authors
- [ ] Press ↓ / ↑ to highlight, Enter to add the highlighted suggestion → list shows the plugin **name**, not the slug
- [ ] Verify the JSON preview at the bottom of the panel still contains only the slug string (no `name` field)
- [ ] Click "Show more" once — additional results append
- [ ] Type a bogus slug (e.g. `nonexistentplugin123`) and press Enter — adds as free-form; list shows the slug as a fallback
- [ ] Apply the blueprint, reload the page → plugins list still shows names (resolved from `/api/plugins/info`)
- [ ] Hit "Test in Playground" on a blueprint with searched plugins — install succeeds end to end
- [ ] Themes section input still behaves the same (no dropdown)