### PR TITLE
DEVREL-1388: WordPress.org theme search + active-theme + reorder

### DIFF
--- a/client/Sidebar/BlueprintPanel.jsx
+++ b/client/Sidebar/BlueprintPanel.jsx
@@ -77,7 +77,7 @@ export function BlueprintPanel() {
         title="Plugins" sectionId="section-plugins"
         items={formState.plugins} onUpdate={(plugins) => updateForm({ plugins })}
         itemType="plugin" inputId="bf-plugin-slug"
-        inputPlaceholder="Search WordPress.org or enter a slug"
+        inputPlaceholder="Search WordPress.org"
         onSearch={api.searchPlugins}
         nameMap={pluginNames}
         onLearnName={learnPluginName}
@@ -86,7 +86,7 @@ export function BlueprintPanel() {
         title="Themes" sectionId="section-themes"
         items={formState.themes} onUpdate={(themes) => updateForm({ themes })}
         itemType="theme" inputId="bf-theme-slug"
-        inputPlaceholder="Search WordPress.org or enter a slug"
+        inputPlaceholder="Search WordPress.org"
         variant="theme"
         onSearch={api.searchThemes}
         nameMap={themeNames}

--- a/client/Sidebar/BlueprintPanel.jsx
+++ b/client/Sidebar/BlueprintPanel.jsx
@@ -1,9 +1,10 @@
 import clsx from 'clsx';
-import { useEffect, useState, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { toast } from 'react-toastify';
 import { Dialog } from '../Dialog.jsx';
 import { useAppState } from '../context/AppStateContext.jsx';
 import { blueprintToForm, useBlueprintFormState } from '../state/useBlueprintFormState.js';
+import { useSlugNameResolver } from '../state/useSlugNameResolver.js';
 import { errorMessage } from '../utils/actions.js';
 import { api } from '../utils/api.js';
 import { EnvironmentSection } from '../blueprint/EnvironmentSection.jsx';
@@ -18,71 +19,8 @@ export function BlueprintPanel() {
 
   const [isApplying, setIsApplying] = useState(false);
   const [resetDialogOpen, setResetDialogOpen] = useState(false);
-  const [pluginNames, setPluginNames] = useState({});
-  const [themeNames, setThemeNames] = useState({});
-
-  // Resolve display names for any slug we haven't seen yet. Fires on initial
-  // load and whenever the list grows by a free-form slug. Server caches WP.org
-  // lookups for 5 min, so reloads are cheap.
-  useEffect(() => {
-    const missing = formState.plugins
-      .map((p) => p.slug)
-      .filter((slug) => slug && !pluginNames[slug]);
-    if (missing.length === 0) return undefined;
-
-    let cancelled = false;
-    Promise.all(
-      missing.map(async (slug) => {
-        try {
-          const info = await api.getPluginInfo(slug);
-          return [slug, info?.name || null];
-        } catch {
-          return [slug, null];
-        }
-      }),
-    ).then((pairs) => {
-      if (cancelled) return;
-      const patch = {};
-      for (const [slug, name] of pairs) if (name) patch[slug] = name;
-      if (Object.keys(patch).length > 0) {
-        setPluginNames((prev) => ({ ...prev, ...patch }));
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [formState.plugins, pluginNames]);
-
-  useEffect(() => {
-    const missing = formState.themes
-      .map((t) => t.slug)
-      .filter((slug) => slug && !themeNames[slug]);
-    if (missing.length === 0) return undefined;
-
-    let cancelled = false;
-    Promise.all(
-      missing.map(async (slug) => {
-        try {
-          const info = await api.getThemeInfo(slug);
-          return [slug, info?.name || null];
-        } catch {
-          return [slug, null];
-        }
-      }),
-    ).then((pairs) => {
-      if (cancelled) return;
-      const patch = {};
-      for (const [slug, name] of pairs) if (name) patch[slug] = name;
-      if (Object.keys(patch).length > 0) {
-        setThemeNames((prev) => ({ ...prev, ...patch }));
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [formState.themes, themeNames]);
+  const [pluginNames, learnPluginName] = useSlugNameResolver(formState.plugins, api.getPluginInfo);
+  const [themeNames, learnThemeName] = useSlugNameResolver(formState.themes, api.getThemeInfo);
 
   // Compare on form-state (not compiled JSON) so incidental key-order / shape
   // differences in the on-disk blueprint don't make the form look "dirty".
@@ -140,10 +78,9 @@ export function BlueprintPanel() {
         items={formState.plugins} onUpdate={(plugins) => updateForm({ plugins })}
         itemType="plugin" inputId="bf-plugin-slug"
         inputPlaceholder="Search WordPress.org or enter a slug"
-        variant="plugin"
-        onSearch={(q, opts) => api.searchPlugins(q, opts)}
+        onSearch={api.searchPlugins}
         nameMap={pluginNames}
-        onLearnName={(slug, name) => setPluginNames((prev) => ({ ...prev, [slug]: name }))}
+        onLearnName={learnPluginName}
       />
       <SlugListSection
         title="Themes" sectionId="section-themes"
@@ -151,9 +88,9 @@ export function BlueprintPanel() {
         itemType="theme" inputId="bf-theme-slug"
         inputPlaceholder="Search WordPress.org or enter a slug"
         variant="theme"
-        onSearch={(q, opts) => api.searchThemes(q, opts)}
+        onSearch={api.searchThemes}
         nameMap={themeNames}
-        onLearnName={(slug, name) => setThemeNames((prev) => ({ ...prev, [slug]: name }))}
+        onLearnName={learnThemeName}
       />
       <ContentSection formState={formState} updateForm={updateForm} />
 

--- a/client/Sidebar/BlueprintPanel.jsx
+++ b/client/Sidebar/BlueprintPanel.jsx
@@ -19,10 +19,11 @@ export function BlueprintPanel() {
   const [isApplying, setIsApplying] = useState(false);
   const [resetDialogOpen, setResetDialogOpen] = useState(false);
   const [pluginNames, setPluginNames] = useState({});
+  const [themeNames, setThemeNames] = useState({});
 
-  // Resolve display names for any plugin slug we haven't seen yet. Fires on
-  // initial load and whenever the plugins list grows by a free-form slug.
-  // Server caches WP.org lookups for 5 min, so reloads are cheap.
+  // Resolve display names for any slug we haven't seen yet. Fires on initial
+  // load and whenever the list grows by a free-form slug. Server caches WP.org
+  // lookups for 5 min, so reloads are cheap.
   useEffect(() => {
     const missing = formState.plugins
       .map((p) => p.slug)
@@ -52,6 +53,36 @@ export function BlueprintPanel() {
       cancelled = true;
     };
   }, [formState.plugins, pluginNames]);
+
+  useEffect(() => {
+    const missing = formState.themes
+      .map((t) => t.slug)
+      .filter((slug) => slug && !themeNames[slug]);
+    if (missing.length === 0) return undefined;
+
+    let cancelled = false;
+    Promise.all(
+      missing.map(async (slug) => {
+        try {
+          const info = await api.getThemeInfo(slug);
+          return [slug, info?.name || null];
+        } catch {
+          return [slug, null];
+        }
+      }),
+    ).then((pairs) => {
+      if (cancelled) return;
+      const patch = {};
+      for (const [slug, name] of pairs) if (name) patch[slug] = name;
+      if (Object.keys(patch).length > 0) {
+        setThemeNames((prev) => ({ ...prev, ...patch }));
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [formState.themes, themeNames]);
 
   // Compare on form-state (not compiled JSON) so incidental key-order / shape
   // differences in the on-disk blueprint don't make the form look "dirty".
@@ -109,6 +140,7 @@ export function BlueprintPanel() {
         items={formState.plugins} onUpdate={(plugins) => updateForm({ plugins })}
         itemType="plugin" inputId="bf-plugin-slug"
         inputPlaceholder="Search WordPress.org or enter a slug"
+        variant="plugin"
         onSearch={(q, opts) => api.searchPlugins(q, opts)}
         nameMap={pluginNames}
         onLearnName={(slug, name) => setPluginNames((prev) => ({ ...prev, [slug]: name }))}
@@ -117,7 +149,11 @@ export function BlueprintPanel() {
         title="Themes" sectionId="section-themes"
         items={formState.themes} onUpdate={(themes) => updateForm({ themes })}
         itemType="theme" inputId="bf-theme-slug"
-        inputPlaceholder="WordPress.org theme slug"
+        inputPlaceholder="Search WordPress.org or enter a slug"
+        variant="theme"
+        onSearch={(q, opts) => api.searchThemes(q, opts)}
+        nameMap={themeNames}
+        onLearnName={(slug, name) => setThemeNames((prev) => ({ ...prev, [slug]: name }))}
       />
       <ContentSection formState={formState} updateForm={updateForm} />
 

--- a/client/blueprint/PluginSearchSuggestions.jsx
+++ b/client/blueprint/PluginSearchSuggestions.jsx
@@ -56,8 +56,8 @@ export function PluginSearchSuggestions({
               if (!isAdded) onSelect(r);
             }}
           >
-            {r.icon ? (
-              <img src={r.icon} alt="" className="bf-suggestion-icon" />
+            {r.thumbnail ? (
+              <img src={r.thumbnail} alt="" className="bf-suggestion-icon" />
             ) : (
               <span className="bf-suggestion-icon bf-suggestion-icon--placeholder" aria-hidden="true" />
             )}

--- a/client/blueprint/SlugListSection.jsx
+++ b/client/blueprint/SlugListSection.jsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { PluginSearchSuggestions } from './PluginSearchSuggestions.jsx';
+import { WpOrgSuggestions } from './WpOrgSuggestions.jsx';
 
 const SEARCH_DEBOUNCE_MS = 250;
 
@@ -16,6 +16,7 @@ export function SlugListSection({
   onSearch,
   nameMap,
   onLearnName,
+  variant = 'plugin',
 }) {
   const [slugInput, setSlugInput] = useState('');
   const [searchState, setSearchState] = useState({
@@ -243,7 +244,8 @@ export function SlugListSection({
                   width: dropdownCoords.width,
                 }}
               >
-                <PluginSearchSuggestions
+                <WpOrgSuggestions
+                  variant={variant}
                   query={slugTrimmed}
                   results={searchState.results}
                   loading={searchState.loading}

--- a/client/blueprint/SlugListSection.jsx
+++ b/client/blueprint/SlugListSection.jsx
@@ -1,4 +1,3 @@
-import clsx from 'clsx';
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { WpOrgSuggestions } from './WpOrgSuggestions.jsx';
@@ -36,14 +35,10 @@ export function SlugListSection({
   const [dropdownCoords, setDropdownCoords] = useState(null);
 
   const slugTrimmed = slugInput.trim();
-  const isDuplicate = items.some((item) => item.slug === slugTrimmed);
-  const canAdd = slugTrimmed.length > 0 && !isDuplicate;
-  const dupWarnId = `${inputId}-dup-warn`;
   const listId = `${inputId}-suggestions`;
   const existingSlugs = useMemo(() => new Set(items.map((i) => i.slug)), [items]);
 
   useEffect(() => {
-    if (!onSearch) return undefined;
     if (!slugTrimmed) {
       setSearchState({ results: [], loading: false, error: null, query: '', page: 1, pages: 1 });
       setActiveIndex(-1);
@@ -85,7 +80,6 @@ export function SlugListSection({
   }, [slugTrimmed, onSearch]);
 
   async function loadMore() {
-    if (!onSearch) return;
     if (searchState.loading) return;
     if (searchState.page >= searchState.pages) return;
     if (!searchState.query) return;
@@ -128,44 +122,32 @@ export function SlugListSection({
     setActiveIndex(-1);
   }
 
-  function addFromInput() {
-    if (!canAdd) return;
-    addSlug(slugTrimmed, null);
-  }
-
   function removeItem(index) {
     onUpdate(items.filter((_, i) => i !== index));
   }
 
   function handleKeyDown(e) {
-    const hasSuggestions = onSearch && searchState.results.length > 0;
-    if (hasSuggestions) {
-      if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        setActiveIndex((i) => Math.min(i + 1, searchState.results.length - 1));
-        return;
-      }
-      if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        setActiveIndex((i) => Math.max(i - 1, -1));
-        return;
-      }
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        setSearchState({ results: [], loading: false, error: null, query: '' });
-        setActiveIndex(-1);
-        return;
-      }
-      if (e.key === 'Enter' && activeIndex >= 0) {
-        e.preventDefault();
-        const r = searchState.results[activeIndex];
-        if (r) addSlug(r.slug, r.name);
-        return;
-      }
-    }
-    if (e.key === 'Enter') {
+    if (searchState.results.length === 0) return;
+    if (e.key === 'ArrowDown') {
       e.preventDefault();
-      addFromInput();
+      setActiveIndex((i) => Math.min(i + 1, searchState.results.length - 1));
+      return;
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(i - 1, -1));
+      return;
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      setSearchState({ results: [], loading: false, error: null, query: '' });
+      setActiveIndex(-1);
+      return;
+    }
+    if (e.key === 'Enter' && activeIndex >= 0) {
+      e.preventDefault();
+      const r = searchState.results[activeIndex];
+      if (r) addSlug(r.slug, r.name);
     }
   }
 
@@ -182,7 +164,6 @@ export function SlugListSection({
   }
 
   const showSuggestions =
-    onSearch &&
     isFocused &&
     slugTrimmed.length > 0 &&
     (searchState.loading ||
@@ -214,80 +195,71 @@ export function SlugListSection({
       <details className="bfs-collapsible">
       <summary className="bfs-summary" id={sectionId}>{title}</summary>
       <div className="bf-fields">
-        <div className="bf-slug-row">
-          <div className="bf-slug-input-wrap">
-            <input
-              ref={inputRef}
-              id={inputId}
-              type="text"
-              className={clsx('bf-input', isDuplicate && slugTrimmed && 'bf-input-warn')}
-              value={slugInput}
-              onChange={(e) => setSlugInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-              onFocus={handleFocus}
-              onBlur={handleBlur}
-              placeholder={inputPlaceholder}
-              aria-label={`${title.slice(0, -1)} slug`}
-              aria-describedby={isDuplicate && slugTrimmed ? dupWarnId : undefined}
-              aria-autocomplete={onSearch ? 'list' : undefined}
-              aria-controls={onSearch ? listId : undefined}
-              aria-expanded={onSearch ? showSuggestions : undefined}
-              autoComplete="off"
-            />
-            {showSuggestions && dropdownCoords && createPortal(
-              <div
-                className="bf-suggestions-portal"
-                style={{
-                  position: 'fixed',
-                  top: dropdownCoords.top,
-                  left: dropdownCoords.left,
-                  width: dropdownCoords.width,
-                }}
-              >
-                <WpOrgSuggestions
-                  variant={variant}
-                  query={slugTrimmed}
-                  results={searchState.results}
-                  loading={searchState.loading}
-                  error={searchState.error}
-                  existingSlugs={existingSlugs}
-                  activeIndex={activeIndex}
-                  listId={listId}
-                  hasMore={searchState.page < searchState.pages}
-                  onLoadMore={loadMore}
-                  onSelect={(r) => addSlug(r.slug, r.name)}
-                  onHoverIndex={setActiveIndex}
-                />
-              </div>,
-              document.body,
-            )}
-          </div>
-          <button
-            type="button"
-            className="bf-add-btn"
-            onClick={addFromInput}
-            disabled={!canAdd}
-            aria-label={`Add ${itemType}`}
-          >
-            Add
-          </button>
+        <div className="bf-slug-input-wrap">
+          <input
+            ref={inputRef}
+            id={inputId}
+            type="text"
+            className="bf-input"
+            value={slugInput}
+            onChange={(e) => setSlugInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            placeholder={inputPlaceholder}
+            aria-label={`Search ${title.toLowerCase()}`}
+            aria-autocomplete="list"
+            aria-controls={listId}
+            aria-expanded={showSuggestions}
+            autoComplete="off"
+          />
+          {showSuggestions && dropdownCoords && createPortal(
+            <div
+              className="bf-suggestions-portal"
+              style={{
+                position: 'fixed',
+                top: dropdownCoords.top,
+                left: dropdownCoords.left,
+                width: dropdownCoords.width,
+              }}
+            >
+              <WpOrgSuggestions
+                variant={variant}
+                query={slugTrimmed}
+                results={searchState.results}
+                loading={searchState.loading}
+                error={searchState.error}
+                existingSlugs={existingSlugs}
+                activeIndex={activeIndex}
+                listId={listId}
+                hasMore={searchState.page < searchState.pages}
+                onLoadMore={loadMore}
+                onSelect={(r) => addSlug(r.slug, r.name)}
+                onHoverIndex={setActiveIndex}
+              />
+            </div>,
+            document.body,
+          )}
         </div>
-
-        {isDuplicate && slugTrimmed && (
-          <p id={dupWarnId} className="bf-warn">
-            "{slugTrimmed}" is already in the list.
-          </p>
-        )}
 
         {items.length > 0 && (
           <ul className="bf-item-list" aria-label={`${title} list`}>
             {items.map((item, index) => {
               const displayName = (nameMap && nameMap[item.slug]) || item.slug;
+              const isActiveTheme = variant === 'theme' && index === items.length - 1;
               return (
                 <li key={item.slug} className="bf-item">
                   <span className="bf-item-label">
                     <span className="bf-item-primary">{displayName}</span>
                   </span>
+                  {isActiveTheme && (
+                    <span
+                      className="bf-item-badge"
+                      title="This is the active theme after the blueprint runs"
+                    >
+                      Active
+                    </span>
+                  )}
                   <button
                     type="button"
                     className="bf-remove-btn"

--- a/client/blueprint/SlugListSection.jsx
+++ b/client/blueprint/SlugListSection.jsx
@@ -126,6 +126,14 @@ export function SlugListSection({
     onUpdate(items.filter((_, i) => i !== index));
   }
 
+  function moveItem(index, delta) {
+    const target = index + delta;
+    if (target < 0 || target >= items.length) return;
+    const next = items.slice();
+    [next[index], next[target]] = [next[target], next[index]];
+    onUpdate(next);
+  }
+
   function handleKeyDown(e) {
     if (searchState.results.length === 0) return;
     if (e.key === 'ArrowDown') {
@@ -247,6 +255,7 @@ export function SlugListSection({
             {items.map((item, index) => {
               const displayName = (nameMap && nameMap[item.slug]) || item.slug;
               const isActiveTheme = variant === 'theme' && index === items.length - 1;
+              const canReorder = variant === 'theme' && items.length > 1;
               return (
                 <li key={item.slug} className="bf-item">
                   <span className="bf-item-label">
@@ -259,6 +268,28 @@ export function SlugListSection({
                     >
                       Active
                     </span>
+                  )}
+                  {canReorder && (
+                    <div className="bf-item-reorder" role="group" aria-label="Reorder">
+                      <button
+                        type="button"
+                        className="bf-reorder-btn"
+                        onClick={() => moveItem(index, -1)}
+                        disabled={index === 0}
+                        aria-label={`Move ${item.slug} up`}
+                      >
+                        ↑
+                      </button>
+                      <button
+                        type="button"
+                        className="bf-reorder-btn"
+                        onClick={() => moveItem(index, 1)}
+                        disabled={index === items.length - 1}
+                        aria-label={`Move ${item.slug} down`}
+                      >
+                        ↓
+                      </button>
+                    </div>
                   )}
                   <button
                     type="button"

--- a/client/blueprint/WpOrgSuggestions.jsx
+++ b/client/blueprint/WpOrgSuggestions.jsx
@@ -44,48 +44,77 @@ export function WpOrgSuggestions({
       {results.map((r, i) => {
         const isAdded = existingSlugs.has(r.slug);
         return (
-          <button
-            type="button"
-            key={r.slug}
-            role="option"
-            aria-selected={i === activeIndex}
-            disabled={isAdded}
-            className={clsx(
-              'bf-suggestion',
-              i === activeIndex && 'is-active',
-              isAdded && 'is-added',
-            )}
-            onMouseEnter={() => onHoverIndex(i)}
-            onMouseDown={(e) => {
-              e.preventDefault();
-              if (!isAdded) onSelect(r);
-            }}
-          >
-            {r.thumbnail ? (
-              <img
-                src={r.thumbnail}
-                alt=""
-                className={clsx('bf-suggestion-icon', `bf-suggestion-icon--${variant}`)}
-              />
-            ) : (
-              <span
-                className={clsx(
-                  'bf-suggestion-icon',
-                  `bf-suggestion-icon--${variant}`,
-                  'bf-suggestion-icon--placeholder',
-                )}
-                aria-hidden="true"
-              />
-            )}
-            <span className="bf-suggestion-body">
-              <span className="bf-suggestion-name">{r.name}</span>
-              {r.author && <span className="bf-suggestion-meta">by {r.author}</span>}
-              {r.shortDescription && (
-                <span className="bf-suggestion-desc">{r.shortDescription}</span>
+          <div key={r.slug} className="bf-suggestion-row">
+            <button
+              type="button"
+              role="option"
+              aria-selected={i === activeIndex}
+              disabled={isAdded}
+              className={clsx(
+                'bf-suggestion',
+                i === activeIndex && 'is-active',
+                isAdded && 'is-added',
               )}
-            </span>
-            {isAdded && <span className="bf-suggestion-added">Added</span>}
-          </button>
+              onMouseEnter={() => onHoverIndex(i)}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                if (!isAdded) onSelect(r);
+              }}
+            >
+              {r.thumbnail ? (
+                <img
+                  src={r.thumbnail}
+                  alt=""
+                  className={clsx('bf-suggestion-icon', `bf-suggestion-icon--${variant}`)}
+                />
+              ) : (
+                <span
+                  className={clsx(
+                    'bf-suggestion-icon',
+                    `bf-suggestion-icon--${variant}`,
+                    'bf-suggestion-icon--placeholder',
+                  )}
+                  aria-hidden="true"
+                />
+              )}
+              <span className="bf-suggestion-body">
+                <span className="bf-suggestion-name">{r.name}</span>
+                {r.author && <span className="bf-suggestion-meta">by {r.author}</span>}
+                {r.shortDescription && (
+                  <span className="bf-suggestion-desc">{r.shortDescription}</span>
+                )}
+              </span>
+              {isAdded && <span className="bf-suggestion-added">Added</span>}
+            </button>
+            {r.previewUrl && (
+              <a
+                className="bf-suggestion-preview"
+                href={r.previewUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`View ${r.name} on WordPress.org`}
+                onMouseDown={(e) => {
+                  // The row button uses onMouseDown to add the slug while
+                  // keeping input focus. Mirror that here: handle the open on
+                  // mousedown for left-click so the input-blur path doesn't
+                  // tear the portal down before a click event fires.
+                  if (e.button !== 0) return;
+                  e.preventDefault();
+                  e.stopPropagation();
+                  window.open(r.previewUrl, '_blank', 'noopener,noreferrer');
+                }}
+                onClick={(e) => {
+                  // Suppress the synthesized click for the same left-button
+                  // gesture (otherwise we'd open the link twice). Keyboard
+                  // activation fires click with detail === 0; let that
+                  // through so Enter still works.
+                  if (e.detail > 0) e.preventDefault();
+                }}
+              >
+                ↗
+              </a>
+            )}
+          </div>
         );
       })}
       {hasMore && !showInlineLoading && (

--- a/client/blueprint/WpOrgSuggestions.jsx
+++ b/client/blueprint/WpOrgSuggestions.jsx
@@ -1,6 +1,8 @@
 import clsx from 'clsx';
 
-export function PluginSearchSuggestions({
+const EMPTY_LABEL = { plugin: 'plugins', theme: 'themes' };
+
+export function WpOrgSuggestions({
   query,
   results,
   loading,
@@ -12,6 +14,7 @@ export function PluginSearchSuggestions({
   onSelect,
   onHoverIndex,
   onLoadMore,
+  variant = 'plugin',
 }) {
   if (!query) return null;
 
@@ -34,7 +37,9 @@ export function PluginSearchSuggestions({
         </div>
       )}
       {showEmpty && (
-        <div className="bf-suggestions-status">No plugins found for "{query}"</div>
+        <div className="bf-suggestions-status">
+          No {EMPTY_LABEL[variant] || 'results'} found for "{query}"
+        </div>
       )}
       {results.map((r, i) => {
         const isAdded = existingSlugs.has(r.slug);
@@ -57,9 +62,20 @@ export function PluginSearchSuggestions({
             }}
           >
             {r.thumbnail ? (
-              <img src={r.thumbnail} alt="" className="bf-suggestion-icon" />
+              <img
+                src={r.thumbnail}
+                alt=""
+                className={clsx('bf-suggestion-icon', `bf-suggestion-icon--${variant}`)}
+              />
             ) : (
-              <span className="bf-suggestion-icon bf-suggestion-icon--placeholder" aria-hidden="true" />
+              <span
+                className={clsx(
+                  'bf-suggestion-icon',
+                  `bf-suggestion-icon--${variant}`,
+                  'bf-suggestion-icon--placeholder',
+                )}
+                aria-hidden="true"
+              />
             )}
             <span className="bf-suggestion-body">
               <span className="bf-suggestion-name">{r.name}</span>

--- a/client/blueprint/WpOrgSuggestions.jsx
+++ b/client/blueprint/WpOrgSuggestions.jsx
@@ -1,7 +1,5 @@
 import clsx from 'clsx';
 
-const EMPTY_LABEL = { plugin: 'plugins', theme: 'themes' };
-
 export function WpOrgSuggestions({
   query,
   results,
@@ -38,7 +36,7 @@ export function WpOrgSuggestions({
       )}
       {showEmpty && (
         <div className="bf-suggestions-status">
-          No {EMPTY_LABEL[variant] || 'results'} found for "{query}"
+          No {variant}s found for "{query}"
         </div>
       )}
       {results.map((r, i) => {
@@ -65,14 +63,14 @@ export function WpOrgSuggestions({
                 <img
                   src={r.thumbnail}
                   alt=""
-                  className={clsx('bf-suggestion-icon', `bf-suggestion-icon--${variant}`)}
+                  className={clsx('bf-suggestion-icon', variant === 'theme' && 'bf-suggestion-icon--theme')}
                 />
               ) : (
                 <span
                   className={clsx(
                     'bf-suggestion-icon',
-                    `bf-suggestion-icon--${variant}`,
                     'bf-suggestion-icon--placeholder',
+                    variant === 'theme' && 'bf-suggestion-icon--theme',
                   )}
                   aria-hidden="true"
                 />
@@ -94,20 +92,17 @@ export function WpOrgSuggestions({
                 rel="noopener noreferrer"
                 aria-label={`View ${r.name} on WordPress.org`}
                 onMouseDown={(e) => {
-                  // The row button uses onMouseDown to add the slug while
-                  // keeping input focus. Mirror that here: handle the open on
-                  // mousedown for left-click so the input-blur path doesn't
-                  // tear the portal down before a click event fires.
+                  // Open on mousedown for left-click — the input-blur path on
+                  // the parent section can tear the portal down before a
+                  // synthesized click would fire on the anchor.
                   if (e.button !== 0) return;
                   e.preventDefault();
                   e.stopPropagation();
                   window.open(r.previewUrl, '_blank', 'noopener,noreferrer');
                 }}
                 onClick={(e) => {
-                  // Suppress the synthesized click for the same left-button
-                  // gesture (otherwise we'd open the link twice). Keyboard
-                  // activation fires click with detail === 0; let that
-                  // through so Enter still works.
+                  // Suppress the duplicate left-click open. Keyboard activation
+                  // (Enter) fires click with detail === 0; let it fall through.
                   if (e.detail > 0) e.preventDefault();
                 }}
               >

--- a/client/state/useBlueprintFormState.js
+++ b/client/state/useBlueprintFormState.js
@@ -167,11 +167,16 @@ export function formToBlueprint(form, schema) {
     blueprint.plugins = pluginEntries.map((p) => p.slug);
   }
 
-  // 4. Install + activate each theme unconditionally
-  for (const t of form.themes) {
-    if (!t.slug) continue;
+  // 4. Install every theme; activate only the last one (WordPress can only
+  //    have one active theme at a time, so additional activate steps would
+  //    just overwrite each other — make the intent explicit instead).
+  const themeEntries = form.themes.filter((t) => t.slug);
+  for (const t of themeEntries) {
     steps.push({ step: 'installTheme', themeData: { resource: 'wordpress.org/themes', slug: t.slug } });
-    steps.push({ step: 'activateTheme', themeFolderName: t.slug });
+  }
+  if (themeEntries.length > 0) {
+    const activeTheme = themeEntries[themeEntries.length - 1];
+    steps.push({ step: 'activateTheme', themeFolderName: activeTheme.slug });
   }
 
   // 7. Sample posts

--- a/client/state/useSlugNameResolver.js
+++ b/client/state/useSlugNameResolver.js
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Resolves human-readable display names for a list of WP.org slugs by calling
+ * the supplied `fetchInfo` API helper. Fires whenever the slug list grows by a
+ * slug we haven't seen. Server caches lookups for 5 min, so reloads are cheap.
+ *
+ * Returns `[nameMap, learnName]`:
+ *   - `nameMap`  — { [slug]: name }
+ *   - `learnName(slug, name)` — record a name learned elsewhere (e.g. by
+ *     clicking a search suggestion that already carries the name)
+ */
+export function useSlugNameResolver(items, fetchInfo) {
+  const [nameMap, setNameMap] = useState({});
+
+  useEffect(() => {
+    const missing = items
+      .map((it) => it.slug)
+      .filter((slug) => slug && !nameMap[slug]);
+    if (missing.length === 0) return undefined;
+
+    let cancelled = false;
+    Promise.all(
+      missing.map(async (slug) => {
+        try {
+          const info = await fetchInfo(slug);
+          return [slug, info?.name || null];
+        } catch {
+          return [slug, null];
+        }
+      }),
+    ).then((pairs) => {
+      if (cancelled) return;
+      const patch = {};
+      for (const [slug, name] of pairs) if (name) patch[slug] = name;
+      if (Object.keys(patch).length > 0) {
+        setNameMap((prev) => ({ ...prev, ...patch }));
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [items, nameMap, fetchInfo]);
+
+  function learnName(slug, name) {
+    setNameMap((prev) => ({ ...prev, [slug]: name }));
+  }
+
+  return [nameMap, learnName];
+}

--- a/client/utils/api.js
+++ b/client/utils/api.js
@@ -154,6 +154,17 @@ export const api = {
     return requestJSON(`/api/plugins/search?${params.toString()}`, { signal });
   },
 
+  async getThemeInfo(slug, { signal } = {}) {
+    const params = new URLSearchParams({ slug });
+    return requestJSON(`/api/themes/info?${params.toString()}`, { signal });
+  },
+
+  async searchThemes(q, { page = 1, signal } = {}) {
+    const params = new URLSearchParams({ q });
+    if (page !== 1) params.set("page", String(page));
+    return requestJSON(`/api/themes/search?${params.toString()}`, { signal });
+  },
+
   startRun(endpoint, body, signal) {
     return apiRequest(endpoint, postOptions(body, { signal }));
   },

--- a/public/style.css
+++ b/public/style.css
@@ -747,6 +747,11 @@ header p {
   background: #1a2035;
 }
 
+.bf-suggestion-icon--theme {
+  width: 64px;
+  height: 48px;
+}
+
 .bf-suggestion-icon--placeholder {
   display: inline-block;
   border: 1px solid #2d3748;

--- a/public/style.css
+++ b/public/style.css
@@ -550,38 +550,6 @@ header p {
 
 /* ── Blueprint Plugins / Themes sections ─────────────────── */
 
-.bf-slug-row {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-}
-
-.bf-slug-row .bf-input { flex: 1; min-width: 0; }
-
-.bf-add-btn {
-  padding: 0.5rem 1rem;
-  background: #6366f1;
-  color: #fff;
-  border: none;
-  border-radius: 6px;
-  font-size: 0.875rem;
-  font-weight: 500;
-  cursor: pointer;
-  white-space: nowrap;
-  transition: background 0.15s;
-}
-
-.bf-add-btn:hover:not(:disabled) { background: #4f46e5; }
-.bf-add-btn:disabled { opacity: 0.4; cursor: not-allowed; }
-
-.bf-input-warn { border-color: #f59e0b !important; }
-
-.bf-warn {
-  color: #f59e0b;
-  font-size: 0.82rem;
-  margin: 0.25rem 0 0;
-}
-
 .bf-item-list {
   list-style: none;
   margin: 0.25rem 0 0;
@@ -599,6 +567,19 @@ header p {
   border: 1px solid #2d3748;
   border-radius: 6px;
   padding: 0.5rem 0.75rem;
+}
+
+.bf-item-badge {
+  flex-shrink: 0;
+  padding: 0.1rem 0.45rem;
+  background: rgba(99, 102, 241, 0.15);
+  color: #a5b4fc;
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
 }
 
 .bf-remove-btn {

--- a/public/style.css
+++ b/public/style.css
@@ -712,21 +712,47 @@ header p {
 
 .bf-suggestions-more:hover { background: #1a2035; }
 
+.bf-suggestion-row {
+  display: flex;
+  align-items: stretch;
+  border-bottom: 1px solid #1e2433;
+}
+
+.bf-suggestion-row:last-child { border-bottom: none; }
+
 .bf-suggestion {
+  flex: 1;
+  min-width: 0;
   display: flex;
   align-items: flex-start;
   gap: 0.6rem;
   padding: 0.55rem 0.75rem;
   background: transparent;
   border: none;
-  border-bottom: 1px solid #1e2433;
   text-align: left;
   cursor: pointer;
   color: #e2e8f0;
   transition: background 0.1s;
 }
 
-.bf-suggestion:last-child { border-bottom: none; }
+.bf-suggestion-preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  flex-shrink: 0;
+  color: #94a3b8;
+  text-decoration: none;
+  font-size: 0.95rem;
+  transition: background 0.1s, color 0.1s;
+}
+
+.bf-suggestion-preview:hover,
+.bf-suggestion-preview:focus-visible {
+  background: #1a2035;
+  color: #e2e8f0;
+  outline: none;
+}
 
 .bf-suggestion.is-active,
 .bf-suggestion:hover:not(:disabled) {

--- a/public/style.css
+++ b/public/style.css
@@ -582,6 +582,40 @@ header p {
   text-transform: uppercase;
 }
 
+.bf-item-reorder {
+  display: flex;
+  flex-shrink: 0;
+  gap: 2px;
+}
+
+.bf-reorder-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  background: transparent;
+  color: #94a3b8;
+  border: 1px solid #2d3748;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+}
+
+.bf-reorder-btn:hover:not(:disabled) {
+  background: #1a2035;
+  color: #e2e8f0;
+  border-color: #475569;
+}
+
+.bf-reorder-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
 .bf-remove-btn {
   padding: 0.25rem 0.6rem;
   background: transparent;

--- a/server.js
+++ b/server.js
@@ -40,6 +40,7 @@ require('./server/routes/directions').register(app);
 require('./server/routes/runner').register(app);
 require('./server/routes/recordings').register(app);
 require('./server/routes/plugins').register(app);
+require('./server/routes/themes').register(app);
 
 const PORT = process.env.PORT || DEFAULT_SERVER_PORT;
 

--- a/server/lib/wporg.js
+++ b/server/lib/wporg.js
@@ -1,0 +1,77 @@
+// @ts-check
+
+/**
+ * Shared helpers for the WordPress.org plugin/theme directory proxies.
+ *
+ * Each route gets its own cache instance via createCache() so keys don't have
+ * to be prefixed and TTLs can diverge later without entangling consumers.
+ */
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_MAX = 100;
+
+function createCache({ ttlMs = DEFAULT_TTL_MS, max = DEFAULT_MAX } = {}) {
+  const store = new Map();
+
+  function get(key) {
+    const entry = store.get(key);
+    if (!entry) return null;
+    if (Date.now() - entry.t > ttlMs) {
+      store.delete(key);
+      return null;
+    }
+    // Refresh LRU position.
+    store.delete(key);
+    store.set(key, entry);
+    return entry.v;
+  }
+
+  function set(key, value) {
+    if (store.size >= max) {
+      const oldest = store.keys().next().value;
+      if (oldest !== undefined) store.delete(oldest);
+    }
+    store.set(key, { t: Date.now(), v: value });
+  }
+
+  return { get, set };
+}
+
+const NAMED_ENTITIES = {
+  amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ',
+  hellip: '…', mdash: '—', ndash: '–',
+  lsquo: '‘', rsquo: '’', ldquo: '“', rdquo: '”',
+  laquo: '«', raquo: '»', copy: '©', reg: '®', trade: '™',
+};
+
+function decodeEntities(s) {
+  return s.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (match, code) => {
+    if (code[0] === '#') {
+      const hex = code[1] === 'x' || code[1] === 'X';
+      const n = parseInt(code.slice(hex ? 2 : 1), hex ? 16 : 10);
+      return Number.isFinite(n) ? String.fromCodePoint(n) : match;
+    }
+    const v = NAMED_ENTITIES[code.toLowerCase()];
+    return v != null ? v : match;
+  });
+}
+
+function stripHtml(s) {
+  if (typeof s !== 'string') return '';
+  return decodeEntities(s.replace(/<[^>]*>/g, '')).trim();
+}
+
+// WP.org sometimes returns protocol-relative URLs (`//ts.w.org/...`). Force
+// https so the browser doesn't have to guess.
+function normalizeThumbnail(url) {
+  if (typeof url !== 'string' || !url) return null;
+  if (url.startsWith('//')) return `https:${url}`;
+  return url;
+}
+
+module.exports = {
+  createCache,
+  decodeEntities,
+  stripHtml,
+  normalizeThumbnail,
+};

--- a/server/lib/wporg.js
+++ b/server/lib/wporg.js
@@ -71,7 +71,6 @@ function normalizeThumbnail(url) {
 
 module.exports = {
   createCache,
-  decodeEntities,
   stripHtml,
   normalizeThumbnail,
 };

--- a/server/routes/plugins.js
+++ b/server/routes/plugins.js
@@ -37,7 +37,7 @@ function normalize(upstream) {
       version: p.version,
       shortDescription: stripHtml(p.short_description),
       thumbnail: pickIcon(p.icons),
-      previewUrl: p.slug ? `https://wordpress.org/plugins/${p.slug}/` : null,
+      previewUrl: `https://wordpress.org/plugins/${p.slug}/`,
       activeInstalls: p.active_installs,
       rating: p.rating,
     })),

--- a/server/routes/plugins.js
+++ b/server/routes/plugins.js
@@ -37,6 +37,7 @@ function normalize(upstream) {
       version: p.version,
       shortDescription: stripHtml(p.short_description),
       thumbnail: pickIcon(p.icons),
+      previewUrl: p.slug ? `https://wordpress.org/plugins/${p.slug}/` : null,
       activeInstalls: p.active_installs,
       rating: p.rating,
     })),

--- a/server/routes/plugins.js
+++ b/server/routes/plugins.js
@@ -4,64 +4,20 @@
  * WordPress.org plugin directory search proxy.
  *
  *   GET /api/plugins/search?q=<term>&page=<n>
+ *   GET /api/plugins/info?slug=<slug>
  *
- * Proxies api.wordpress.org's keyless query_plugins endpoint, trims the
- * response to just what the UI needs, and caches results in memory for 5
- * minutes. The proxy isolates the UI from CORS / endpoint changes and lets
+ * Proxies api.wordpress.org's keyless query_plugins / plugin_information
+ * endpoints, trims the response to just what the UI needs, and caches results
+ * in memory. The proxy isolates the UI from CORS / endpoint changes and lets
  * us normalize errors in one place.
  */
 
-const CACHE_TTL_MS = 5 * 60 * 1000;
-const CACHE_MAX = 100;
+const { createCache, stripHtml } = require('../lib/wporg');
+
 const PER_PAGE = 10;
 const MAX_QUERY_LEN = 100;
 
-const cache = new Map();
-
-function cacheGet(key) {
-  const entry = cache.get(key);
-  if (!entry) return null;
-  if (Date.now() - entry.t > CACHE_TTL_MS) {
-    cache.delete(key);
-    return null;
-  }
-  // Refresh LRU position.
-  cache.delete(key);
-  cache.set(key, entry);
-  return entry.v;
-}
-
-function cacheSet(key, value) {
-  if (cache.size >= CACHE_MAX) {
-    const oldest = cache.keys().next().value;
-    if (oldest !== undefined) cache.delete(oldest);
-  }
-  cache.set(key, { t: Date.now(), v: value });
-}
-
-const NAMED_ENTITIES = {
-  amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ',
-  hellip: '…', mdash: '—', ndash: '–',
-  lsquo: '‘', rsquo: '’', ldquo: '“', rdquo: '”',
-  laquo: '«', raquo: '»', copy: '©', reg: '®', trade: '™',
-};
-
-function decodeEntities(s) {
-  return s.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (match, code) => {
-    if (code[0] === '#') {
-      const hex = code[1] === 'x' || code[1] === 'X';
-      const n = parseInt(code.slice(hex ? 2 : 1), hex ? 16 : 10);
-      return Number.isFinite(n) ? String.fromCodePoint(n) : match;
-    }
-    const v = NAMED_ENTITIES[code.toLowerCase()];
-    return v != null ? v : match;
-  });
-}
-
-function stripHtml(s) {
-  if (typeof s !== 'string') return '';
-  return decodeEntities(s.replace(/<[^>]*>/g, '')).trim();
-}
+const cache = createCache();
 
 function pickIcon(icons) {
   if (!icons || typeof icons !== 'object') return null;
@@ -80,7 +36,7 @@ function normalize(upstream) {
       author: stripHtml(p.author),
       version: p.version,
       shortDescription: stripHtml(p.short_description),
-      icon: pickIcon(p.icons),
+      thumbnail: pickIcon(p.icons),
       activeInstalls: p.active_installs,
       rating: p.rating,
     })),
@@ -96,7 +52,7 @@ function register(app) {
     }
 
     const cacheKey = `info|${slug}`;
-    const cached = cacheGet(cacheKey);
+    const cached = cache.get(cacheKey);
     if (cached) {
       res.set('X-Cache', 'HIT');
       return res.json(cached);
@@ -119,9 +75,9 @@ function register(app) {
         slug: json.slug,
         name: stripHtml(json.name),
         author: stripHtml(json.author),
-        icon: pickIcon(json.icons),
+        thumbnail: pickIcon(json.icons),
       };
-      cacheSet(cacheKey, normalized);
+      cache.set(cacheKey, normalized);
       res.set('X-Cache', 'MISS');
       res.json(normalized);
     } catch (err) {
@@ -140,7 +96,7 @@ function register(app) {
     }
 
     const cacheKey = `${q}|${page}`;
-    const cached = cacheGet(cacheKey);
+    const cached = cache.get(cacheKey);
     if (cached) {
       res.set('X-Cache', 'HIT');
       return res.json(cached);
@@ -165,7 +121,7 @@ function register(app) {
       }
       const json = await upstream.json();
       const normalized = normalize(json);
-      cacheSet(cacheKey, normalized);
+      cache.set(cacheKey, normalized);
       res.set('X-Cache', 'MISS');
       res.json(normalized);
     } catch (err) {

--- a/server/routes/themes.js
+++ b/server/routes/themes.js
@@ -45,6 +45,7 @@ function normalize(upstream) {
       version: t.version,
       shortDescription: shortDescription(t.description),
       thumbnail: normalizeThumbnail(t.screenshot_url),
+      previewUrl: t.preview_url || null,
       downloaded: t.downloaded,
       rating: t.rating,
     })),
@@ -116,7 +117,7 @@ function register(app) {
       per_page: String(PER_PAGE),
       page: String(page),
     });
-    for (const f of ['description', 'screenshot_url', 'rating', 'downloaded']) {
+    for (const f of ['description', 'screenshot_url', 'preview_url', 'rating', 'downloaded']) {
       params.append('fields[]', f);
     }
     const url = `https://api.wordpress.org/themes/info/1.2/?${params.toString()}`;

--- a/server/routes/themes.js
+++ b/server/routes/themes.js
@@ -1,0 +1,142 @@
+// @ts-check
+
+/**
+ * WordPress.org theme directory search proxy.
+ *
+ *   GET /api/themes/search?q=<term>&page=<n>
+ *   GET /api/themes/info?slug=<slug>
+ *
+ * Mirrors server/routes/plugins.js for themes. The themes endpoint differs
+ * from plugins in a few field names: `screenshot_url` (a single image) instead
+ * of `icons`, `author` is an object (not an HTML string), and there's no
+ * `active_installs` (we surface `downloaded` instead).
+ */
+
+const { createCache, stripHtml, normalizeThumbnail } = require('../lib/wporg');
+
+const PER_PAGE = 10;
+const MAX_QUERY_LEN = 100;
+const MAX_DESC_LEN = 200;
+
+const cache = createCache();
+
+function authorString(author) {
+  if (!author) return '';
+  if (typeof author === 'string') return stripHtml(author);
+  return stripHtml(author.display_name || author.user_nicename || '');
+}
+
+function shortDescription(s) {
+  const text = stripHtml(s);
+  if (text.length <= MAX_DESC_LEN) return text;
+  return `${text.slice(0, MAX_DESC_LEN - 1).trimEnd()}…`;
+}
+
+function normalize(upstream) {
+  const info = upstream && upstream.info ? upstream.info : {};
+  const themes = Array.isArray(upstream && upstream.themes) ? upstream.themes : [];
+  return {
+    page: info.page || 1,
+    pages: info.pages || 1,
+    results: themes.map((t) => ({
+      slug: t.slug,
+      name: stripHtml(t.name),
+      author: authorString(t.author),
+      version: t.version,
+      shortDescription: shortDescription(t.description),
+      thumbnail: normalizeThumbnail(t.screenshot_url),
+      downloaded: t.downloaded,
+      rating: t.rating,
+    })),
+  };
+}
+
+function register(app) {
+  app.get('/api/themes/info', async (req, res) => {
+    const slug = typeof req.query.slug === 'string' ? req.query.slug.trim() : '';
+    if (!slug) return res.status(400).json({ error: 'slug is required' });
+    if (slug.length > MAX_QUERY_LEN || !/^[a-z0-9._-]+$/i.test(slug)) {
+      return res.status(400).json({ error: 'invalid slug' });
+    }
+
+    const cacheKey = `info|${slug}`;
+    const cached = cache.get(cacheKey);
+    if (cached) {
+      res.set('X-Cache', 'HIT');
+      return res.json(cached);
+    }
+
+    const params = new URLSearchParams({ action: 'theme_information', slug });
+    const url = `https://api.wordpress.org/themes/info/1.2/?${params.toString()}`;
+
+    try {
+      const upstream = await fetch(url);
+      if (!upstream.ok) {
+        return res.status(502).json({ error: `Upstream returned ${upstream.status}` });
+      }
+      const json = await upstream.json();
+      // WP.org returns `false` (not an error envelope) for unknown theme slugs.
+      if (!json || typeof json !== 'object' || !json.slug) {
+        return res.status(404).json({ error: 'theme not found' });
+      }
+      const normalized = {
+        slug: json.slug,
+        name: stripHtml(json.name),
+        author: authorString(json.author),
+        thumbnail: normalizeThumbnail(json.screenshot_url),
+      };
+      cache.set(cacheKey, normalized);
+      res.set('X-Cache', 'MISS');
+      res.json(normalized);
+    } catch (err) {
+      console.error('[themes/info] fetch failed:', err.message);
+      res.status(502).json({ error: 'Failed to reach WordPress.org' });
+    }
+  });
+
+  app.get('/api/themes/search', async (req, res) => {
+    const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+    const page = Math.max(1, parseInt(String(req.query.page || '1'), 10) || 1);
+
+    if (!q) return res.status(400).json({ error: 'q is required' });
+    if (q.length > MAX_QUERY_LEN) {
+      return res.status(400).json({ error: `q too long (max ${MAX_QUERY_LEN})` });
+    }
+
+    const cacheKey = `${q}|${page}`;
+    const cached = cache.get(cacheKey);
+    if (cached) {
+      res.set('X-Cache', 'HIT');
+      return res.json(cached);
+    }
+
+    const params = new URLSearchParams({
+      action: 'query_themes',
+      search: q,
+      per_page: String(PER_PAGE),
+      page: String(page),
+    });
+    for (const f of ['description', 'screenshot_url', 'rating', 'downloaded']) {
+      params.append('fields[]', f);
+    }
+    const url = `https://api.wordpress.org/themes/info/1.2/?${params.toString()}`;
+
+    try {
+      const upstream = await fetch(url);
+      if (!upstream.ok) {
+        console.error(`[themes/search] upstream ${upstream.status} for q=${q}`);
+        return res.status(502).json({ error: `Upstream returned ${upstream.status}` });
+      }
+      const json = await upstream.json();
+      const normalized = normalize(json);
+      cache.set(cacheKey, normalized);
+      res.set('X-Cache', 'MISS');
+      res.json(normalized);
+    } catch (err) {
+      console.error('[themes/search] fetch failed:', err.message);
+      res.status(502).json({ error: 'Failed to reach WordPress.org' });
+    }
+  });
+}
+
+module.exports = { register };


### PR DESCRIPTION
## Summary
- Add WP.org theme search to the Blueprint UI: typing in the Themes input hits a new `/api/themes/search` proxy and renders an image-forward dropdown (screenshot thumbnail + name + author + description), mirroring the plugin lookup.
- Refactor the WP.org proxy: extract a `server/lib/wporg.js` with a per-route `createCache()` factory plus shared `stripHtml`/`normalizeThumbnail`, and rename plugin response field `icon` → `thumbnail` so plugins and themes share one suggestion component (`WpOrgSuggestions` with a `variant` prop).
- Per-item ↗ link on every suggestion opens wp.org in a new tab (theme live preview / plugin directory page). Uses `mousedown` + `window.open` to dodge the input-blur path that was tearing down the dropdown before the synthesized click would fire.
- Drop free-form slug input — plugins and themes can now only be added by selecting a search result. Removes the Add button, `canAdd`/`addFromInput`/`isDuplicate`-warning paths and associated CSS.
- Active theme indicator: WordPress can only have one active theme, so the compile now installs every theme but only emits one `activateTheme` step for the last entry (previously emitted one per theme that silently overwrote each other). The UI shows an "Active" pill on the last theme.
- Up/down reorder controls on theme items so the user can pick the active theme without removing and re-adding.
- Refactor: pull plugin/theme display-name resolution out of `BlueprintPanel` into a `useSlugNameResolver` hook (replaces two near-identical 30-line `useEffect` blocks).

## Test plan
- [ ] `curl 'http://localhost:3000/api/themes/search?q=twenty' | jq '.results[0]'` returns trimmed result with `thumbnail`, `previewUrl`, `author` string
- [ ] `curl 'http://localhost:3000/api/themes/info?slug=twentytwentyfive' | jq` returns name + author + thumbnail
- [ ] Plugin search still works end to end (regression check on the rename)
- [ ] Type "twenty" in the Themes input — dropdown shows screenshots + "Add" badge on already-added themes
- [ ] Click a result → theme appears in the list with display name; blueprint JSON contains only the slug string
- [ ] Click the ↗ on a plugin and a theme suggestion → both open wp.org in a new tab
- [ ] Add 2+ themes → "Active" badge sits on the last; ↑/↓ buttons reorder; activating different theme via reorder produces the expected `activateTheme` step in the compiled JSON
- [ ] Existing theme slugs in a loaded blueprint resolve to display names on mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)