### PR TITLE
DEVREL-1409: Add format & resolution options to video download

### DIFF
--- a/client/Sidebar/RecordingsPanel.jsx
+++ b/client/Sidebar/RecordingsPanel.jsx
@@ -44,16 +44,45 @@ function DownloadMenu({ recording, onClose }) {
     };
   }, [onClose]);
 
-  const size = recording.sourceSize;
-  const sizeLabel = size ? `${size.width}×${size.height}` : 'source';
+  const sizes = recording.downloadSizes?.length
+    ? recording.downloadSizes
+    : (recording.sourceSize ? [recording.sourceSize] : []);
   const base = `/api/recordings/${encodeURIComponent(recording.dirname)}/download`;
+
+  function url(format, size) {
+    const params = new URLSearchParams({ format });
+    if (size) {
+      params.set('width', String(size.width));
+      params.set('height', String(size.height));
+    }
+    return `${base}?${params.toString()}`;
+  }
+
+  function renderSection(format, label) {
+    if (!sizes.length) {
+      return (
+        <a className="download-menu-item" role="menuitem" href={url(format)} onClick={onClose}>source</a>
+      );
+    }
+    return sizes.map((size) => (
+      <a
+        key={`${format}-${size.width}x${size.height}`}
+        className="download-menu-item"
+        role="menuitem"
+        href={url(format, size)}
+        onClick={onClose}
+      >
+        {`${size.width}×${size.height}`}
+      </a>
+    ));
+  }
 
   return (
     <div className="download-menu" ref={ref} role="menu">
       <div className="download-menu-section-label">WebM</div>
-      <a className="download-menu-item" role="menuitem" href={`${base}?format=webm`} onClick={onClose}>{sizeLabel}</a>
+      {renderSection('webm')}
       <div className="download-menu-section-label">MP4</div>
-      <a className="download-menu-item" role="menuitem" href={`${base}?format=mp4`} onClick={onClose}>{sizeLabel}</a>
+      {renderSection('mp4')}
     </div>
   );
 }

--- a/client/Sidebar/RecordingsPanel.jsx
+++ b/client/Sidebar/RecordingsPanel.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { toast } from 'react-toastify';
 import { Dialog } from '../Dialog.jsx';
 import { useAppState } from '../context/AppStateContext.jsx';
@@ -26,11 +26,44 @@ function PreviewIcon() {
   );
 }
 
+function DownloadMenu({ recording, onClose }) {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    function handleDocClick(event) {
+      if (ref.current && !ref.current.contains(event.target)) onClose();
+    }
+    function handleKey(event) {
+      if (event.key === 'Escape') onClose();
+    }
+    document.addEventListener('mousedown', handleDocClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleDocClick);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [onClose]);
+
+  const size = recording.sourceSize;
+  const sizeLabel = size ? `${size.width}×${size.height}` : 'source';
+  const base = `/api/recordings/${encodeURIComponent(recording.dirname)}/download`;
+
+  return (
+    <div className="download-menu" ref={ref} role="menu">
+      <div className="download-menu-section-label">WebM</div>
+      <a className="download-menu-item" role="menuitem" href={`${base}?format=webm`} onClick={onClose}>{sizeLabel}</a>
+      <div className="download-menu-section-label">MP4</div>
+      <a className="download-menu-item" role="menuitem" href={`${base}?format=mp4`} onClick={onClose}>{sizeLabel}</a>
+    </div>
+  );
+}
+
 export function RecordingsPanel() {
   const { recordings } = useAppState();
   const { running, showPreviewVideo } = useRunState();
   const deleteRecordingMutation = useDeleteRecordingMutation();
   const [pendingDeleteRecording, setPendingDeleteRecording] = useState(null);
+  const [downloadMenuFor, setDownloadMenuFor] = useState(null);
   const deletingRecording = deleteRecordingMutation.isPending;
 
   function closeDeleteDialog() {
@@ -65,7 +98,7 @@ export function RecordingsPanel() {
               const fileSize = formatFileSize(recording.size);
               const timestamp = formatTimestamp(recording.createdAt);
               const videoUrl = `/api/recordings/${recording.dirname}/video`;
-              const downloadName = `${recording.filenameBase ?? recording.slug ?? recording.dirname}.${recording.ext ?? 'mp4'}`;
+              const downloadOpen = downloadMenuFor === recording.dirname;
 
               return (
                 <div className="recording-item" key={recording.dirname}>
@@ -88,15 +121,25 @@ export function RecordingsPanel() {
                     >
                       <PreviewIcon />
                     </button>
-                    <a
-                      className="recording-download-btn recording-action-btn secondary"
-                      href={videoUrl}
-                      aria-label={`Download ${recording.name}`}
-                      title="Download"
-                      download={downloadName}
-                    >
-                      <DownloadIcon />
-                    </a>
+                    <span className="recording-download-wrap">
+                      <button
+                        className="recording-download-btn recording-action-btn secondary"
+                        type="button"
+                        aria-label={`Download ${recording.name}`}
+                        aria-haspopup="menu"
+                        aria-expanded={downloadOpen}
+                        title="Download"
+                        onClick={() => setDownloadMenuFor(downloadOpen ? null : recording.dirname)}
+                      >
+                        <DownloadIcon />
+                      </button>
+                      {downloadOpen && (
+                        <DownloadMenu
+                          recording={recording}
+                          onClose={() => setDownloadMenuFor(null)}
+                        />
+                      )}
+                    </span>
                     <button
                       className="recording-delete-btn sidebar-delete-icon-btn recording-action-btn danger"
                       type="button"

--- a/public/style.css
+++ b/public/style.css
@@ -1771,6 +1771,43 @@ header p {
 .recording-preview-btn:hover,
 .recording-download-btn:hover { border-color: #6b7280; color: #e2e8f0; }
 
+.recording-download-wrap {
+  display: inline-block;
+  position: relative;
+}
+
+.download-menu {
+  background: #111827;
+  border: 1px solid #374151;
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  min-width: 9rem;
+  padding: 4px 0;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  z-index: 50;
+}
+
+.download-menu-section-label {
+  color: #64748b;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 4px 12px 2px;
+  text-transform: uppercase;
+}
+
+.download-menu-item {
+  color: #e2e8f0;
+  display: block;
+  font-size: 0.82rem;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.download-menu-item:hover { background: #243046; }
+
 .recording-preview-btn:disabled {
   border-color: #2d3748;
   color: #374151;

--- a/server/routes/recordings.js
+++ b/server/routes/recordings.js
@@ -153,10 +153,11 @@ function resolveRecordingDir(dirname) {
 function register(app) {
   app.get('/api/recordings', async (req, res) => {
     if (!fs.existsSync(OUTPUT_DIR)) return res.json({ recordings: [] });
-    const dirs = fs.readdirSync(OUTPUT_DIR).filter(d => isListableRecordingDir(d) && findVideoFile(d) !== null);
-    const recordings = await Promise.all(dirs.map(async (dirname) => {
-      const found = findVideoFile(dirname);
-      // findVideoFile returned non-null from the filter above, so this is safe.
+    const entries = fs.readdirSync(OUTPUT_DIR)
+      .filter(isListableRecordingDir)
+      .map((dirname) => ({ dirname, found: findVideoFile(dirname) }))
+      .filter((entry) => entry.found !== null);
+    const recordings = await Promise.all(entries.map(async ({ dirname, found }) => {
       const { file, ext } = /** @type {NonNullable<typeof found>} */ (found);
       const stat = fs.statSync(file);
       const recording = parseRecordingDirname(dirname);

--- a/server/routes/recordings.js
+++ b/server/routes/recordings.js
@@ -3,25 +3,25 @@
 /**
  * Recordings list + download.
  *
- *   GET    /api/recordings                  → list all completed recordings
- *   GET    /api/recordings/:dirname/video   → stream the MP4 (or WebM fallback)
- *   DELETE /api/recordings/:dirname         → delete one completed recording
+ *   GET    /api/recordings                       → list all completed recordings
+ *   GET    /api/recordings/:dirname/video        → stream the canonical WebM
+ *   GET    /api/recordings/:dirname/download     → download as ?format=webm|mp4
+ *   DELETE /api/recordings/:dirname              → delete one completed recording
  *
  * "Recordings" == directories under `output/` that have a video file.
  * Playwright names them `actions-runner-<test-name>-chromium`; UI recordings
  * use `<recording-name>-<timestamp>`. We strip the runner/chromium wrapper and
  * parse the timestamp so the UI can show a clean title plus a readable date.
  *
- * Why prefer MP4? After /api/run's ffmpeg step, an MP4 sits alongside the
- * WebM. We serve MP4 when present (universal playback, matches user's chosen
- * size) and fall back to WebM only if conversion failed.
+ * WebM is the only persisted artifact. MP4 downloads are produced on demand
+ * via ffmpeg, streamed to the response, and never written to disk.
  */
 
 const fs = require('fs');
 const path = require('path');
 const rangeParser = require('range-parser');
 const { OUTPUT_DIR, SCREENCASTS_DIR } = require('../config');
-const { findVideoFile } = require('../video');
+const { findVideoFile, probeVideoSize, spawnMp4Transcode } = require('../video');
 
 const TIMESTAMP_PATTERN = /^(.+)-(\d{8}T\d{6}Z)(?:-\d+)?$/;
 const RUNNER_PREFIX = 'actions-runner-';
@@ -104,17 +104,19 @@ function resolveRecordingDir(dirname) {
 }
 
 function register(app) {
-  app.get('/api/recordings', (req, res) => {
+  app.get('/api/recordings', async (req, res) => {
     if (!fs.existsSync(OUTPUT_DIR)) return res.json({ recordings: [] });
     const dirs = fs.readdirSync(OUTPUT_DIR).filter(d => isListableRecordingDir(d) && findVideoFile(d) !== null);
-    const recordings = dirs.map((dirname) => {
+    const recordings = await Promise.all(dirs.map(async (dirname) => {
       const found = findVideoFile(dirname);
       // findVideoFile returned non-null from the filter above, so this is safe.
       const { file, ext } = /** @type {NonNullable<typeof found>} */ (found);
       const stat = fs.statSync(file);
       const recording = parseRecordingDirname(dirname);
-      return { ...recording, dirname, ext, size: stat.size, mtime: stat.mtimeMs };
-    }).sort((a, b) => b.mtime - a.mtime);
+      const sourceSize = await probeVideoSize(file);
+      return { ...recording, dirname, ext, size: stat.size, mtime: stat.mtimeMs, sourceSize };
+    }));
+    recordings.sort((a, b) => b.mtime - a.mtime);
     res.json({ recordings });
   });
 
@@ -124,13 +126,13 @@ function register(app) {
     if (!isSafeRecordingDirname(dirname)) return res.status(400).end();
     const found = findVideoFile(dirname);
     if (!found) return res.status(404).end();
-    const { filenameBase } = parseRecordingDirname(dirname);
+    const { slug } = parseRecordingDirname(dirname);
     const stat = fs.statSync(found.file);
     const range = req.headers.range;
 
     res.setHeader('Accept-Ranges', 'bytes');
     res.setHeader('Content-Type', found.mime);
-    res.setHeader('Content-Disposition', `attachment; filename="${filenameBase}.${found.ext}"`);
+    res.setHeader('Content-Disposition', `attachment; filename="${slug}.${found.ext}"`);
 
     if (!range) {
       res.setHeader('Content-Length', stat.size);
@@ -151,6 +153,49 @@ function register(app) {
     res.setHeader('Content-Range', `bytes ${start}-${end}/${stat.size}`);
     res.setHeader('Content-Length', end - start + 1);
     fs.createReadStream(found.file, { start, end }).pipe(res);
+  });
+
+  app.get('/api/recordings/:dirname/download', (req, res) => {
+    const dirname = req.params.dirname;
+    if (!isSafeRecordingDirname(dirname)) return res.status(400).end();
+    const format = String(req.query.format || '').toLowerCase();
+    if (format !== 'webm' && format !== 'mp4') return res.status(400).end();
+
+    const found = findVideoFile(dirname);
+    if (!found) return res.status(404).end();
+    const { slug } = parseRecordingDirname(dirname);
+
+    if (format === 'webm') {
+      // Source-resolution WebM is served straight from disk.
+      const stat = fs.statSync(found.file);
+      res.setHeader('Content-Type', 'video/webm');
+      res.setHeader('Content-Length', stat.size);
+      res.setHeader('Content-Disposition', `attachment; filename="${slug}.webm"`);
+      fs.createReadStream(found.file).pipe(res);
+      return;
+    }
+
+    // MP4: transcode on demand, stream directly, never persist.
+    res.setHeader('Content-Type', 'video/mp4');
+    res.setHeader('Content-Disposition', `attachment; filename="${slug}.mp4"`);
+
+    const ff = spawnMp4Transcode(found.file, null);
+    let killed = false;
+    const kill = () => {
+      if (killed) return;
+      killed = true;
+      try { ff.kill('SIGKILL'); } catch {}
+    };
+    res.on('close', () => { if (!res.writableEnded) kill(); });
+    ff.stdout.pipe(res);
+    ff.stderr.on('data', () => {}); // drain to avoid backpressure
+    ff.on('error', () => {
+      if (!res.headersSent) res.status(500);
+      if (!res.writableEnded) res.end();
+    });
+    ff.on('close', (code) => {
+      if (code !== 0 && !res.writableEnded) res.end();
+    });
   });
 
   app.delete('/api/recordings/:dirname', (req, res) => {

--- a/server/routes/recordings.js
+++ b/server/routes/recordings.js
@@ -21,7 +21,54 @@ const fs = require('fs');
 const path = require('path');
 const rangeParser = require('range-parser');
 const { OUTPUT_DIR, SCREENCASTS_DIR } = require('../config');
-const { findVideoFile, probeVideoSize, spawnMp4Transcode } = require('../video');
+const { findVideoFile, probeVideoSize, spawnMp4Transcode, spawnWebmDownscale } = require('../video');
+const { VIDEO_SIZE_PRESETS } = require('../video-size');
+
+/**
+ * Resolutions a recording can be downloaded at: the captured source size,
+ * plus any preset whose width is strictly smaller. Sorted largest-first.
+ *
+ * @param {{ width: number, height: number }} sourceSize
+ * @returns {{ width: number, height: number }[]}
+ */
+function allowedSizesFor(sourceSize) {
+  const smaller = VIDEO_SIZE_PRESETS
+    .filter((p) => p.width < sourceSize.width)
+    .map((p) => ({ width: p.width, height: p.height }));
+  return [{ width: sourceSize.width, height: sourceSize.height }, ...smaller]
+    .sort((a, b) => b.width - a.width);
+}
+
+/**
+ * Resolve `width`+`height` query params to a target size, or return a status
+ * code on rejection. `null` means "no resize" (source resolution).
+ *
+ * @returns {{ kind: 'source' } | { kind: 'scale', size: { width: number, height: number } } | { kind: 'error', status: number }}
+ */
+function resolveDownloadSize(query, sourceSize) {
+  const rawW = query.width;
+  const rawH = query.height;
+  if (rawW == null && rawH == null) return { kind: 'source' };
+  if (rawW == null || rawH == null) return { kind: 'error', status: 400 };
+
+  const width = Number(rawW);
+  const height = Number(rawH);
+  if (!Number.isFinite(width) || !Number.isFinite(height)) {
+    return { kind: 'error', status: 400 };
+  }
+
+  if (!sourceSize) return { kind: 'error', status: 400 };
+  if (width === sourceSize.width && height === sourceSize.height) {
+    return { kind: 'source' };
+  }
+
+  const isAllowedPreset = VIDEO_SIZE_PRESETS.some(
+    (p) => p.width === width && p.height === height && p.width < sourceSize.width,
+  );
+  if (!isAllowedPreset) return { kind: 'error', status: 400 };
+
+  return { kind: 'scale', size: { width, height } };
+}
 
 const TIMESTAMP_PATTERN = /^(.+)-(\d{8}T\d{6}Z)(?:-\d+)?$/;
 const RUNNER_PREFIX = 'actions-runner-';
@@ -114,7 +161,8 @@ function register(app) {
       const stat = fs.statSync(file);
       const recording = parseRecordingDirname(dirname);
       const sourceSize = await probeVideoSize(file);
-      return { ...recording, dirname, ext, size: stat.size, mtime: stat.mtimeMs, sourceSize };
+      const downloadSizes = sourceSize ? allowedSizesFor(sourceSize) : [];
+      return { ...recording, dirname, ext, size: stat.size, mtime: stat.mtimeMs, sourceSize, downloadSizes };
     }));
     recordings.sort((a, b) => b.mtime - a.mtime);
     res.json({ recordings });
@@ -155,7 +203,7 @@ function register(app) {
     fs.createReadStream(found.file, { start, end }).pipe(res);
   });
 
-  app.get('/api/recordings/:dirname/download', (req, res) => {
+  app.get('/api/recordings/:dirname/download', async (req, res) => {
     const dirname = req.params.dirname;
     if (!isSafeRecordingDirname(dirname)) return res.status(400).end();
     const format = String(req.query.format || '').toLowerCase();
@@ -165,21 +213,32 @@ function register(app) {
     if (!found) return res.status(404).end();
     const { slug } = parseRecordingDirname(dirname);
 
-    if (format === 'webm') {
-      // Source-resolution WebM is served straight from disk.
+    const sourceSize = await probeVideoSize(found.file);
+    const target = resolveDownloadSize(req.query, sourceSize);
+    if (target.kind === 'error') return res.status(target.status).end();
+
+    const outSize = target.kind === 'scale' ? target.size : sourceSize;
+    const dimsSuffix = outSize ? `-${outSize.width}x${outSize.height}` : '';
+    const filename = `${slug}${dimsSuffix}.${format}`;
+
+    if (format === 'webm' && target.kind === 'source') {
       const stat = fs.statSync(found.file);
       res.setHeader('Content-Type', 'video/webm');
       res.setHeader('Content-Length', stat.size);
-      res.setHeader('Content-Disposition', `attachment; filename="${slug}.webm"`);
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
       fs.createReadStream(found.file).pipe(res);
       return;
     }
 
-    // MP4: transcode on demand, stream directly, never persist.
-    res.setHeader('Content-Type', 'video/mp4');
-    res.setHeader('Content-Disposition', `attachment; filename="${slug}.mp4"`);
+    const mime = format === 'mp4' ? 'video/mp4' : 'video/webm';
+    res.setHeader('Content-Type', mime);
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
 
-    const ff = spawnMp4Transcode(found.file, null);
+    const scaleSize = target.kind === 'scale' ? target.size : null;
+    const ff = format === 'mp4'
+      ? spawnMp4Transcode(found.file, scaleSize)
+      : spawnWebmDownscale(found.file, /** @type {{width:number,height:number}} */ (scaleSize));
+
     let killed = false;
     const kill = () => {
       if (killed) return;

--- a/server/routes/runner.js
+++ b/server/routes/runner.js
@@ -18,9 +18,7 @@
  *      each script's step definitions in order.
  *   4. Stream stdout/stderr and live screencast frames back to the client as
  *      SSE events.
- *   5. After all scripts finish, run the ffmpeg post-process step to produce
- *      an MP4.
- *   6. Call pool.release() so the used slot is rebooted in the background,
+ *   5. Call pool.release() so the used slot is rebooted in the background,
  *      ready for the run after next.
  *
  * ## SSE event contract
@@ -44,7 +42,6 @@ const {
   GENERATED_BLUEPRINT,
 } = require('../config');
 const pool = require('../playground-server');
-const { processVideo } = require('../video');
 const { normalizeVideoSize, screencastSizeForVideoSize, sizeKey } = require('../video-size');
 const { timestamp, timestampedDirname, uniqueDir } = require('../output-paths');
 const { nameToFilename, normalizeRecordingSettings, scriptForRun } = require('./scripts');
@@ -287,9 +284,6 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
       await page.close();
       if (run?.page === page) run.page = null;
       if (video && recordedVideoPath) await video.saveAs(recordedVideoPath);
-      if (shouldSaveRecording && recordedVideoPath && code === 0) {
-        await processVideo(recordedVideoPath, null, send);
-      }
     }
 
     await context.close();

--- a/server/video.js
+++ b/server/video.js
@@ -20,36 +20,9 @@ const { OUTPUT_DIR } = require('./config');
 /**
  * @typedef {Object} VideoFile
  * @property {string} file  Absolute path to the video.
- * @property {'mp4'|'webm'} ext
+ * @property {'webm'} ext
  * @property {string} mime
  */
-
-/**
- * @typedef {Object} VideoSize
- * @property {number} width
- * @property {number} height
- */
-
-/**
- * @typedef {(event: { type: 'stdout'|'stderr', text: string }) => void} Sender
- */
-
-/**
- * Locate the most-recently-modified output directory that has a `video.webm`.
- * Playwright names dirs like `steps-runner-<test-name>-chromium`; we pick the
- * newest by mtime so the ffmpeg step operates on the test that just finished.
- *
- * @returns {string | null}  Directory name (not full path), or null if none found.
- */
-function findNewestVideoDir() {
-  if (!fs.existsSync(OUTPUT_DIR)) return null;
-  const dirs = fs.readdirSync(OUTPUT_DIR)
-    .filter(d => !d.startsWith('.'))
-    .filter(d => fs.existsSync(path.join(OUTPUT_DIR, d, 'video.webm')))
-    .map(d => ({ d, mtime: fs.statSync(path.join(OUTPUT_DIR, d)).mtimeMs }))
-    .sort((a, b) => b.mtime - a.mtime);
-  return dirs[0]?.d ?? null;
-}
 
 /**
  * Locate the canonical WebM file inside an output directory. Returned shape
@@ -141,4 +114,4 @@ function spawnWebmDownscale(inputPath, targetSize) {
   ]);
 }
 
-module.exports = { findVideoFile, findNewestVideoDir, probeVideoSize, spawnMp4Transcode, spawnWebmDownscale };
+module.exports = { findVideoFile, probeVideoSize, spawnMp4Transcode, spawnWebmDownscale };

--- a/server/video.js
+++ b/server/video.js
@@ -1,12 +1,11 @@
 // @ts-check
 
 /**
- * Video post-processing: convert Playwright's `video.webm` to MP4 (H.264 + AAC)
- * and optionally scale to a user-chosen size.
+ * Video helpers.
  *
- * Playwright outputs WebM per-test. Most downstream tools (Keynote, Slack,
- * QuickTime, social) prefer MP4, so we always convert. Callers may optionally
- * pass a target size when they need a scale pass.
+ * WebM is the canonical persisted artifact (captured directly by Playwright).
+ * MP4 and downscaled WebM are produced on demand by ffmpeg and streamed to
+ * the client — never written to disk.
  *
  * ffmpeg is shipped via the `ffmpeg-static` npm package — no system install
  * required, which matters for the long-term goal of a distributable app.
@@ -17,7 +16,6 @@ const path = require('path');
 const { spawn } = require('child_process');
 const ffmpegPath = require('ffmpeg-static');
 const { OUTPUT_DIR } = require('./config');
-const { normalizeVideoSize } = require('./video-size');
 
 /**
  * @typedef {Object} VideoFile
@@ -54,72 +52,93 @@ function findNewestVideoDir() {
 }
 
 /**
- * Locate a video file inside an output directory, preferring MP4 over WebM
- * (MP4 only exists after a successful conversion). Returned shape includes
- * MIME + extension so callers can set Content-Type / Content-Disposition
+ * Locate the canonical WebM file inside an output directory. Returned shape
+ * includes MIME + extension so callers can set Content-Type / Content-Disposition
  * without guessing.
  *
  * @param {string} dirname  Directory name inside OUTPUT_DIR.
  * @returns {VideoFile | null}
  */
 function findVideoFile(dirname) {
-  const mp4 = path.join(OUTPUT_DIR, dirname, 'video.mp4');
-  if (fs.existsSync(mp4)) return { file: mp4, ext: 'mp4', mime: 'video/mp4' };
   const webm = path.join(OUTPUT_DIR, dirname, 'video.webm');
   if (fs.existsSync(webm)) return { file: webm, ext: 'webm', mime: 'video/webm' };
   return null;
 }
 
 /**
- * Convert a specific WebM recording to MP4, optionally scaling.
- * No-op if the input file does not exist.
+ * Probe a video file for its width/height. Uses ffmpeg's stderr banner — we
+ * don't ship ffprobe-static. Result is cached by absolute path + mtime so
+ * repeated calls from `/api/recordings` are cheap.
  *
- * Resolves regardless of ffmpeg's exit code — we don't want conversion
- * failures to fail the whole run. On failure we delete the partial MP4 and
- * notify the caller via SSE; the WebM stays in place as a fallback.
- *
- * @param {string} inputPath            Absolute path to the source `video.webm`.
- * @param {VideoSize | null} videoSize  Optional target size; null → no scale.
- * @param {Sender} send                 SSE forwarder for ffmpeg output.
- * @returns {Promise<void>}
+ * @param {string} filePath
+ * @returns {Promise<{ width: number, height: number } | null>}
  */
-function processVideo(inputPath, videoSize, send) {
-  return new Promise((resolve) => {
-    if (!fs.existsSync(inputPath)) return resolve();
-    const outputPath = path.join(path.dirname(inputPath), 'video.mp4');
+const probeCache = new Map();
+function probeVideoSize(filePath) {
+  let stat;
+  try { stat = fs.statSync(filePath); } catch { return Promise.resolve(null); }
+  const cacheKey = `${filePath}:${stat.mtimeMs}`;
+  const cached = probeCache.get(cacheKey);
+  if (cached) return cached;
 
-    const targetSize = videoSize ? normalizeVideoSize(videoSize, null) : null;
-    const label = targetSize
-      ? `Converting to MP4 and scaling to ${targetSize.width}×${targetSize.height}`
-      : 'Converting to MP4';
-    send({ type: 'stdout', text: `[ffmpeg] ${label}…\n` });
-
-    const scaleFilter = targetSize
-      ? [`-vf`, `scale=${targetSize.width}:${targetSize.height}:flags=lanczos`]
-      : [];
-
-    const ff = spawn(ffmpegPath, [
-      '-i', inputPath,
-      ...scaleFilter,
-      // CRF 18 / preset slow = near-visually-lossless at reasonable filesize.
-      '-c:v', 'libx264', '-preset', 'slow', '-crf', '18',
-      '-c:a', 'aac', '-b:a', '192k',
-      '-y', outputPath,
-    ]);
-
-    // ffmpeg writes everything to stderr by design; we tag it as stdout here
-    // so the UI log panel doesn't style the progress output as errors.
-    ff.stderr.on('data', (d) => send({ type: 'stdout', text: `[ffmpeg] ${d}` }));
-    ff.on('close', (code) => {
-      if (code === 0) {
-        send({ type: 'stdout', text: '[ffmpeg] Done.\n' });
-      } else {
-        send({ type: 'stderr', text: `[ffmpeg] Conversion failed (exit ${code})\n` });
-        try { fs.unlinkSync(outputPath); } catch {}
-      }
-      resolve();
+  const promise = new Promise((resolve) => {
+    const ff = spawn(ffmpegPath, ['-hide_banner', '-i', filePath]);
+    let buf = '';
+    ff.stderr.on('data', (d) => { buf += d.toString(); });
+    ff.on('close', () => {
+      // Match "Stream #0:0: Video: ... 1920x1080" — the first WxH near the
+      // Video line. We avoid matching SAR/DAR ratios by anchoring on commas.
+      const match = buf.match(/Video:[^\n]*?(\b\d{2,5})x(\d{2,5})\b/);
+      if (!match) return resolve(null);
+      resolve({ width: Number(match[1]), height: Number(match[2]) });
     });
+    ff.on('error', () => resolve(null));
   });
+  probeCache.set(cacheKey, promise);
+  return promise;
 }
 
-module.exports = { findVideoFile, processVideo };
+/**
+ * Spawn ffmpeg to transcode WebM → MP4 (H.264 + AAC), piping to a writable
+ * stream. Optionally scales to a target size. The child is returned so the
+ * caller can wire its exit to the response lifecycle.
+ *
+ * @param {string} inputPath
+ * @param {{ width: number, height: number } | null} targetSize
+ * @returns {import('child_process').ChildProcessWithoutNullStreams}
+ */
+function spawnMp4Transcode(inputPath, targetSize) {
+  const scaleArgs = targetSize
+    ? ['-vf', `scale=${targetSize.width}:${targetSize.height}:flags=lanczos`]
+    : [];
+  return spawn(ffmpegPath, [
+    '-i', inputPath,
+    ...scaleArgs,
+    '-c:v', 'libx264', '-preset', 'veryfast', '-crf', '20',
+    '-c:a', 'aac', '-b:a', '192k',
+    // Required so MP4 atoms are streamable (moov before mdat).
+    '-movflags', 'frag_keyframe+empty_moov+default_base_moof',
+    '-f', 'mp4',
+    'pipe:1',
+  ]);
+}
+
+/**
+ * Spawn ffmpeg to downscale a WebM to a smaller resolution, piping to stdout
+ * in WebM container.
+ *
+ * @param {string} inputPath
+ * @param {{ width: number, height: number }} targetSize
+ */
+function spawnWebmDownscale(inputPath, targetSize) {
+  return spawn(ffmpegPath, [
+    '-i', inputPath,
+    '-vf', `scale=${targetSize.width}:${targetSize.height}:flags=lanczos`,
+    '-c:v', 'libvpx-vp9', '-crf', '32', '-b:v', '0',
+    '-c:a', 'libopus',
+    '-f', 'webm',
+    'pipe:1',
+  ]);
+}
+
+module.exports = { findVideoFile, findNewestVideoDir, probeVideoSize, spawnMp4Transcode, spawnWebmDownscale };


### PR DESCRIPTION
## Summary
- Replace the single download button with a popover menu offering WebM or MP4 at the source resolution plus any `VIDEO_SIZE_PRESETS` smaller than the capture.
- WebM is the only persisted artifact. MP4 and downscaled WebM are produced on demand by ffmpeg, streamed straight to the response, and never written to disk. The post-run MP4 conversion step is removed.
- New endpoint `GET /api/recordings/:dirname/download?format=<webm|mp4>&width=&height=` with safe-dirname / preset validation (400 on upscale or unknown size, 404 on missing recording).
- Downloaded filenames use the script slug and are suffixed with the output dimensions (e.g. `my-recording-1280x720.mp4`).
- `/api/recordings` now exposes `sourceSize` and `downloadSizes` so the menu can render the right entries without duplicating preset logic on the client.

Linear: https://linear.app/a8c/issue/DEVREL-1409/add-format-and-resolution-options-to-video-download

## Test plan
- [ ] Record a new video, confirm only `video.webm` lands in `output/<dirname>/` (no eager MP4).
- [ ] In the recordings panel, click Download — popover shows WebM and MP4 sections with the source resolution and any smaller preset.
- [ ] Download a source-resolution WebM — arrives instantly, streams from disk.
- [ ] Download a source-resolution MP4 — ffmpeg transcodes and streams; no MP4 left on disk afterward.
- [ ] On a 1080p recording, download 720p WebM and 720p MP4 — both arrive at the correct dimensions and aren't persisted.
- [ ] Hit `/download` with an upscale (e.g. width/height larger than source) and an unknown size — both return 400.
- [ ] Hit `/download` with an unsafe `dirname` (path traversal) — returns 400; missing recording returns 404.
- [ ] In-app preview button still plays the recording (now backed by WebM).