### PR TITLE
DEVREL-1414: Drop dead preview-video pipeline; keep failed-run artifacts

### DIFF
--- a/client/Sidebar/RecordingsPanel.jsx
+++ b/client/Sidebar/RecordingsPanel.jsx
@@ -5,7 +5,7 @@ import { useAppState } from '../context/AppStateContext.jsx';
 import { useRunState } from '../context/RunContext.jsx';
 import { errorMessage } from '../utils/actions.js';
 import { formatFileSize, formatTimestamp } from '../utils/formatters.js';
-import { useDeleteRecordingMutation } from '../utils/apiHooks.js';
+import { useDeleteRecordingMutation, usePreviewsQuery, useClearPreviewsMutation } from '../utils/apiHooks.js';
 import { SectionBadge } from './SectionBadge.jsx';
 import { TrashIcon } from './TrashIcon.jsx';
 
@@ -30,8 +30,21 @@ export function RecordingsPanel() {
   const { recordings } = useAppState();
   const { running, showPreviewVideo } = useRunState();
   const deleteRecordingMutation = useDeleteRecordingMutation();
+  const previewsQuery = usePreviewsQuery();
+  const clearPreviewsMutation = useClearPreviewsMutation();
   const [pendingDeleteRecording, setPendingDeleteRecording] = useState(null);
   const deletingRecording = deleteRecordingMutation.isPending;
+  const failedPreviewCount = previewsQuery.data?.count ?? 0;
+  const clearingPreviews = clearPreviewsMutation.isPending;
+
+  async function clearFailedPreviews() {
+    try {
+      await clearPreviewsMutation.mutateAsync();
+      toast.success(`Cleared ${failedPreviewCount} failed preview${failedPreviewCount === 1 ? '' : 's'}`);
+    } catch (err) {
+      toast.error(errorMessage(err, 'Could not clear previews'));
+    }
+  }
 
   function closeDeleteDialog() {
     if (!deletingRecording) setPendingDeleteRecording(null);
@@ -58,6 +71,21 @@ export function RecordingsPanel() {
           <SectionBadge hidden={recordings.length === 0}>{recordings.length}</SectionBadge>
         </summary>
         <div className="recordings-body">
+          {failedPreviewCount > 0 && (
+            <div className="failed-previews-notice">
+              <span className="hint">
+                {failedPreviewCount} failed preview{failedPreviewCount === 1 ? '' : 's'} kept for debugging
+              </span>
+              <button
+                type="button"
+                className="app-dialog-btn app-dialog-btn--secondary"
+                disabled={clearingPreviews}
+                onClick={clearFailedPreviews}
+              >
+                {clearingPreviews ? 'Clearing...' : 'Clear failed previews'}
+              </button>
+            </div>
+          )}
           <div id="recordings-list">
             {!recordings.length && <p className="hint">No recordings yet - run a script to generate a video.</p>}
 

--- a/client/context/RunContext.jsx
+++ b/client/context/RunContext.jsx
@@ -26,13 +26,14 @@ export function RunProvider({ children }) {
   const runLog = useRunLog();
   const runPreview = useRunPreview();
   const queryClient = useQueryClient();
+  const previewMessageHandler = runPreview.handlePreviewMessage;
   const handlePreviewMessage = useCallback((msg) => {
     if (msg.type === 'previewArtifact') {
       queryClient.invalidateQueries({ queryKey: queryKeys.previews });
       return;
     }
-    runPreview.handlePreviewMessage(msg);
-  }, [queryClient, runPreview]);
+    previewMessageHandler(msg);
+  }, [queryClient, previewMessageHandler]);
   const {
     activeStepIndex,
     running,

--- a/client/context/RunContext.jsx
+++ b/client/context/RunContext.jsx
@@ -1,9 +1,11 @@
-import { createContext, useContext, useMemo } from 'react';
+import { createContext, useCallback, useContext, useMemo } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useRunActions } from '../state/useRunActions.js';
 import { useRunLog } from '../state/useRunLog.js';
 import { useRunPreview } from '../state/useRunPreview.js';
 import { useRunStream } from '../state/useRunStream.js';
 import { useAppState } from './AppStateContext.jsx';
+import { queryKeys } from '../utils/api.js';
 
 const RunContext = createContext(null);
 
@@ -23,6 +25,14 @@ export function RunProvider({ children }) {
 
   const runLog = useRunLog();
   const runPreview = useRunPreview();
+  const queryClient = useQueryClient();
+  const handlePreviewMessage = useCallback((msg) => {
+    if (msg.type === 'previewArtifact') {
+      queryClient.invalidateQueries({ queryKey: queryKeys.previews });
+      return;
+    }
+    runPreview.handlePreviewMessage(msg);
+  }, [queryClient, runPreview]);
   const {
     activeStepIndex,
     running,
@@ -31,7 +41,7 @@ export function RunProvider({ children }) {
     stopRun,
   } = useRunStream({
     appendLog: runLog.appendLog,
-    handlePreviewMessage: runPreview.handlePreviewMessage,
+    handlePreviewMessage,
     markDone: runLog.markDone,
     markFailed: runLog.markFailed,
     markStopped: runLog.markStopped,

--- a/client/state/useRunPreview.js
+++ b/client/state/useRunPreview.js
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 const IDLE_PREVIEW = {
   mode: 'idle',
@@ -12,29 +12,19 @@ const IDLE_PREVIEW = {
 };
 
 export function useRunPreview() {
-  const lastScreencastVideoRef = useRef('');
   const [preview, setPreview] = useState(IDLE_PREVIEW);
 
   const startPreview = useCallback(() => {
-    lastScreencastVideoRef.current = '';
     setPreview({ mode: 'connecting', imageSrc: '', recordedAt: null, videoSrc: '', poster: '', title: '', playgroundPort: null, isLive: false });
   }, []);
 
   const stopPreview = useCallback(() => {
-    const videoSrc = lastScreencastVideoRef.current;
     setPreview((current) => (
-      videoSrc
-        ? (
-          current.mode === 'video' && current.videoSrc === videoSrc
-            ? current
-            : { mode: 'video', imageSrc: '', recordedAt: null, videoSrc, poster: current.imageSrc, title: '', playgroundPort: null, isLive: false }
-        )
-        : (current.mode === 'image' ? { ...current, isLive: false, playgroundPort: null } : IDLE_PREVIEW)
+      current.mode === 'image' ? { ...current, isLive: false, playgroundPort: null } : IDLE_PREVIEW
     ));
   }, []);
 
   const showPreviewVideo = useCallback((videoSrc, { recordedAt = null, title = '' } = {}) => {
-    lastScreencastVideoRef.current = videoSrc;
     setPreview({ mode: 'video', imageSrc: '', recordedAt, videoSrc, poster: '', title, playgroundPort: null, isLive: false });
   }, []);
 
@@ -59,21 +49,6 @@ export function useRunPreview() {
         playgroundPort: null,
         isLive: true,
       });
-      return;
-    }
-
-    if (msg.type === 'screencastVideo') {
-      lastScreencastVideoRef.current = msg.uri;
-      setPreview((current) => ({
-        mode: 'video',
-        imageSrc: '',
-        recordedAt: null,
-        videoSrc: msg.uri,
-        poster: current.imageSrc,
-        title: '',
-        playgroundPort: null,
-        isLive: false,
-      }));
     }
   }, []);
 

--- a/client/utils/api.js
+++ b/client/utils/api.js
@@ -69,6 +69,7 @@ export const queryKeys = {
   },
   recordings: ["recordings"],
   scripts: ["scripts"],
+  previews: ["previews"],
 };
 
 export const api = {
@@ -133,6 +134,15 @@ export const api = {
     return requestJSON(`/api/recordings/${encodeURIComponent(dirname)}`, {
       method: "DELETE",
     });
+  },
+
+  async listPreviews({ signal } = {}) {
+    const data = await requestJSON("/api/previews", { signal });
+    return { count: data?.count ?? 0, items: data?.items ?? [] };
+  },
+
+  async clearPreviews() {
+    return requestJSON("/api/previews", { method: "DELETE" });
   },
 
   async previewBlueprint(blueprint) {

--- a/client/utils/apiHooks.js
+++ b/client/utils/apiHooks.js
@@ -51,6 +51,22 @@ export function useDeleteRecordingMutation() {
   });
 }
 
+export function usePreviewsQuery() {
+  return useQuery({
+    queryKey: queryKeys.previews,
+    queryFn: api.listPreviews,
+  });
+}
+
+export function useClearPreviewsMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: api.clearPreviews,
+    onSuccess: () => invalidate(queryClient, queryKeys.previews),
+  });
+}
+
 export function useDirectionLoader() {
   const queryClient = useQueryClient();
 

--- a/client/utils/apiHooks.js
+++ b/client/utils/apiHooks.js
@@ -55,6 +55,8 @@ export function usePreviewsQuery() {
   return useQuery({
     queryKey: queryKeys.previews,
     queryFn: api.listPreviews,
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "record:actions": "playwright test recordings/actions-runner.spec.js",
     "record:action": "playwright test recordings/actions-runner.spec.js --grep",
     "show-report": "playwright show-report",
-    "show-trace": "playwright show-trace"
+    "show-trace": "playwright show-trace",
+    "clean:previews": "rm -rf output/.previews"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",

--- a/public/style.css
+++ b/public/style.css
@@ -1703,6 +1703,22 @@ header p {
   padding: 0.75rem 1.5rem 1rem;
 }
 
+.failed-previews-notice {
+  align-items: center;
+  border: 1px solid #3b2f12;
+  background: #1a1408;
+  border-radius: 6px;
+  display: flex;
+  gap: 0.6rem;
+  justify-content: space-between;
+  margin-bottom: 0.6rem;
+  padding: 0.55rem 0.75rem;
+}
+
+.failed-previews-notice .hint {
+  margin: 0;
+}
+
 .recording-item {
   align-items: center;
   border-bottom: 1px solid #1a2035;

--- a/server.js
+++ b/server.js
@@ -21,7 +21,6 @@ const fs = require('fs');
 const path = require('path');
 const express = require('express');
 const {
-  SCREENCASTS_DIR,
   DEFAULT_SERVER_PORT,
   DEFAULT_BLUEPRINT,
   GENERATED_BLUEPRINT,
@@ -30,7 +29,6 @@ const {
 const app = express();
 
 app.use(express.json());
-app.use('/screencasts', express.static(SCREENCASTS_DIR));
 
 // Route modules — each registers its own handlers on `app`.
 require('./server/routes/translate').register(app);
@@ -39,6 +37,7 @@ require('./server/routes/scripts').register(app);
 require('./server/routes/directions').register(app);
 require('./server/routes/runner').register(app);
 require('./server/routes/recordings').register(app);
+require('./server/routes/previews').register(app);
 require('./server/routes/plugins').register(app);
 require('./server/routes/themes').register(app);
 

--- a/server/config.js
+++ b/server/config.js
@@ -20,7 +20,6 @@ module.exports = {
   OUTPUT_DIR:              path.join(ROOT, 'output'),
   PLAYWRIGHT_OUTPUT_DIR:   path.join(ROOT, 'output', '.playwright'),
   PREVIEW_OUTPUT_DIR:      path.join(ROOT, 'output', '.previews'),
-  SCREENCASTS_DIR:         path.join(ROOT, 'output', '.screencasts'),
   DIRECTIONS_DIR:          path.join(ROOT, 'directions'),
   BUILTIN_DIRECTIONS_DIR:  path.join(__dirname, 'directions'),
 

--- a/server/routes/previews.js
+++ b/server/routes/previews.js
@@ -1,0 +1,48 @@
+// @ts-check
+
+/**
+ * Failed-preview cleanup.
+ *
+ *   GET    /api/previews   → { count, items: [{ dirname, mtime }] }
+ *   DELETE /api/previews   → empty PREVIEW_OUTPUT_DIR
+ *
+ * Preview runs write a video to `output/.previews/preview-<slug>-<timestamp>/`
+ * so a failing run leaves a debuggable artifact. Successful previews are
+ * deleted by the runner itself; what remains here is the failure backlog.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { PREVIEW_OUTPUT_DIR } = require('../config');
+
+function listPreviewDirs() {
+  if (!fs.existsSync(PREVIEW_OUTPUT_DIR)) return [];
+  return fs.readdirSync(PREVIEW_OUTPUT_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const dir = path.join(PREVIEW_OUTPUT_DIR, entry.name);
+      const stat = fs.statSync(dir);
+      return { dirname: entry.name, mtime: stat.mtimeMs };
+    })
+    .sort((a, b) => b.mtime - a.mtime);
+}
+
+function register(app) {
+  app.get('/api/previews', (req, res) => {
+    const items = listPreviewDirs();
+    res.json({ count: items.length, items });
+  });
+
+  app.delete('/api/previews', (req, res) => {
+    try {
+      if (fs.existsSync(PREVIEW_OUTPUT_DIR)) {
+        fs.rmSync(PREVIEW_OUTPUT_DIR, { recursive: true, force: true });
+      }
+      res.json({ cleared: true });
+    } catch (err) {
+      res.status(500).json({ error: err.message || 'Could not clear previews' });
+    }
+  });
+}
+
+module.exports = { register };

--- a/server/routes/previews.js
+++ b/server/routes/previews.js
@@ -16,8 +16,14 @@ const path = require('path');
 const { PREVIEW_OUTPUT_DIR } = require('../config');
 
 function listPreviewDirs() {
-  if (!fs.existsSync(PREVIEW_OUTPUT_DIR)) return [];
-  return fs.readdirSync(PREVIEW_OUTPUT_DIR, { withFileTypes: true })
+  let entries;
+  try {
+    entries = fs.readdirSync(PREVIEW_OUTPUT_DIR, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === 'ENOENT') return [];
+    throw err;
+  }
+  return entries
     .filter((entry) => entry.isDirectory())
     .map((entry) => {
       const dir = path.join(PREVIEW_OUTPUT_DIR, entry.name);
@@ -35,9 +41,7 @@ function register(app) {
 
   app.delete('/api/previews', (req, res) => {
     try {
-      if (fs.existsSync(PREVIEW_OUTPUT_DIR)) {
-        fs.rmSync(PREVIEW_OUTPUT_DIR, { recursive: true, force: true });
-      }
+      fs.rmSync(PREVIEW_OUTPUT_DIR, { recursive: true, force: true });
       res.json({ cleared: true });
     } catch (err) {
       res.status(500).json({ error: err.message || 'Could not clear previews' });

--- a/server/routes/recordings.js
+++ b/server/routes/recordings.js
@@ -20,7 +20,7 @@
 const fs = require('fs');
 const path = require('path');
 const rangeParser = require('range-parser');
-const { OUTPUT_DIR, SCREENCASTS_DIR } = require('../config');
+const { OUTPUT_DIR } = require('../config');
 const { findVideoFile } = require('../video');
 
 const TIMESTAMP_PATTERN = /^(.+)-(\d{8}T\d{6}Z)(?:-\d+)?$/;
@@ -160,7 +160,6 @@ function register(app) {
 
     try {
       fs.rmSync(dir, { recursive: true, force: false });
-      fs.rmSync(path.join(SCREENCASTS_DIR, `${dirname}.webm`), { force: true });
       res.json({ deleted: true });
     } catch {
       res.status(500).json({ error: 'Could not delete recording' });

--- a/server/routes/runner.js
+++ b/server/routes/runner.js
@@ -28,7 +28,7 @@
  *   { type: 'stdout',     text: string }          — log line from Playwright/ffmpeg
  *   { type: 'stderr',     text: string }          — error line
  *   { type: 'screencast', data: string }          — base64 JPEG frame for live preview
- *   { type: 'screencastVideo', uri: string }      — public URI for the saved screencast video
+ *   { type: 'previewArtifact', dirname: string }  — failed-preview recording kept for debugging
  *   { type: 'done',       code: number, file?: string }  — terminal event; client closes
  */
 
@@ -39,7 +39,6 @@ const {
   OUTPUT_DIR,
   PLAYWRIGHT_OUTPUT_DIR,
   PREVIEW_OUTPUT_DIR,
-  SCREENCASTS_DIR,
   DEFAULT_BLUEPRINT,
   GENERATED_BLUEPRINT,
 } = require('../config');
@@ -213,8 +212,9 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
 
   let browser = null;
   let context = null;
-  let latestPreviewVideoPath = null;
-  let latestPreviewVideoFilename = null;
+  /** @type {string[]} Dirs created under PREVIEW_OUTPUT_DIR during this run; kept on error, deleted on success. */
+  const previewVideoDirs = [];
+  let runErrored = false;
   let instanceUsed = false;
   const markInstanceUsed = () => {
     if (instanceUsed) return;
@@ -250,16 +250,14 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
       });
       throwIfRunStopped(signal);
 
-      let recordedVideoPath = null;
       const outputSlug = nameToFilename(def.name).replace(/\.json$/i, '');
       const outputStamp = timestamp();
       const outputDirname = timestampedDirname(shouldSaveRecording ? outputSlug : `preview-${outputSlug}`, outputStamp);
       const outputRoot = shouldSaveRecording ? OUTPUT_DIR : PREVIEW_OUTPUT_DIR;
       const videoDir = uniqueDir(path.join(outputRoot, outputDirname));
-      recordedVideoPath = path.join(videoDir, 'video.webm');
+      const recordedVideoPath = path.join(videoDir, 'video.webm');
       fs.mkdirSync(videoDir, { recursive: true });
-      latestPreviewVideoPath = recordedVideoPath;
-      latestPreviewVideoFilename = `${path.basename(videoDir)}.webm`;
+      if (!shouldSaveRecording) previewVideoDirs.push(videoDir);
 
       // Load the site before starting the screencast so the video does not start with a blank screen.
       // Use the blueprint's landingPage if specified; otherwise fall back to the WP admin dashboard.
@@ -286,7 +284,7 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
       const video = page.video();
       await page.close();
       if (run?.page === page) run.page = null;
-      if (video && recordedVideoPath) await video.saveAs(recordedVideoPath);
+      if (video) await video.saveAs(recordedVideoPath);
       if (shouldSaveRecording && recordedVideoPath && code === 0) {
         await processVideo(recordedVideoPath, null, send);
       }
@@ -298,6 +296,7 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
     if (signal?.aborted || err.code === 'RUN_STOPPED') {
       if (run) run.stopRequested = true;
     } else {
+      runErrored = true;
       send({ type: 'stderr', text: `[Playwright] ${err.message}\n` });
       code = 1;
     }
@@ -329,11 +328,14 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
     if (run?.browser === browser) run.browser = null;
   }
 
-  if (latestPreviewVideoPath && latestPreviewVideoFilename && fs.existsSync(latestPreviewVideoPath)) {
-    const publicPath = path.join(SCREENCASTS_DIR, latestPreviewVideoFilename);
-    fs.mkdirSync(SCREENCASTS_DIR, { recursive: true });
-    fs.copyFileSync(latestPreviewVideoPath, publicPath);
-    send({ type: 'screencastVideo', uri: `/screencasts/${latestPreviewVideoFilename}` });
+  for (const dir of previewVideoDirs) {
+    if (runErrored) {
+      if (fs.existsSync(path.join(dir, 'video.webm'))) {
+        send({ type: 'previewArtifact', dirname: path.basename(dir) });
+      }
+    } else {
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+    }
   }
 
   send({ type: 'done', code, ...(wasStopped() ? { stopped: true } : {}), ...doneExtra });

--- a/server/routes/runner.js
+++ b/server/routes/runner.js
@@ -212,9 +212,8 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
 
   let browser = null;
   let context = null;
-  /** @type {string[]} Dirs created under PREVIEW_OUTPUT_DIR during this run; kept on error, deleted on success. */
+  /** @type {string[]} Dirs created under PREVIEW_OUTPUT_DIR during this run. Kept when the run errored, deleted on success. */
   const previewVideoDirs = [];
-  let runErrored = false;
   let instanceUsed = false;
   const markInstanceUsed = () => {
     if (instanceUsed) return;
@@ -296,7 +295,6 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
     if (signal?.aborted || err.code === 'RUN_STOPPED') {
       if (run) run.stopRequested = true;
     } else {
-      runErrored = true;
       send({ type: 'stderr', text: `[Playwright] ${err.message}\n` });
       code = 1;
     }
@@ -328,11 +326,10 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
     if (run?.browser === browser) run.browser = null;
   }
 
+  const runFailed = code !== 0 && !wasStopped();
   for (const dir of previewVideoDirs) {
-    if (runErrored) {
-      if (fs.existsSync(path.join(dir, 'video.webm'))) {
-        send({ type: 'previewArtifact', dirname: path.basename(dir) });
-      }
+    if (runFailed) {
+      send({ type: 'previewArtifact', dirname: path.basename(dir) });
     } else {
       try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
     }

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,7 +14,6 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': 'http://localhost:3000',
-      '/screencasts': 'http://localhost:3000',
     },
   },
 });


### PR DESCRIPTION
Linear: https://linear.app/a8c/issue/DEVREL-1414/keep-failed-preview-videos-for-debugging-drop-successful-ones-add

## Summary
- Successful preview runs no longer leave a video on disk — the runner deletes `output/.previews/<slug>/` on success.
- Failed preview runs keep the directory and emit a `previewArtifact` SSE event so the UI can surface a cleanup affordance. Stopped runs (intentional cancel) drop the artifact.
- Removed the dead `.screencasts/` pipeline entirely: copy step, `screencastVideo` SSE event, `/screencasts` static mount + vite proxy, `SCREENCASTS_DIR` config, and the dir-cleanup call in `DELETE /api/recordings/:dirname`.
- Added `GET /api/previews` + `DELETE /api/previews`, a "Clear failed previews" button in the Recordings panel (only shown when count > 0), and an `npm run clean:previews` script.

## Behavior change
The preview panel no longer switches to a saved-video view after a preview run — it goes idle. Per the issue discussion, users rerun to save the proper recording, so post-preview playback wasn't needed. Easy to restore for failed previews only if we change our mind.

## Cleanup pass
Second commit tightens the implementation:
- Dropped the redundant `runErrored` flag in favor of `code !== 0 && !wasStopped()`.
- Removed TOCTOU `fs.existsSync` guards in the post-run loop and the previews route handlers (`rmSync force` / readdir ENOENT handling cover the missing case directly).
- Stabilized `handlePreviewMessage` by depending on the inner stable callback, not the parent object returned by `useRunPreview` (which is a fresh literal each render).
- Quieted `usePreviewsQuery` with `staleTime: Infinity` and `refetchOnWindowFocus: false` — the count only changes on explicit invalidations.

## Test plan
- [ ] Run a preview that succeeds — confirm no entry appears under `output/.previews/`.
- [ ] Force a preview failure (e.g. bad selector) — confirm a directory is kept and the "Clear failed previews" banner appears in the Recordings panel.
- [ ] Stop a preview mid-run — confirm no directory is kept (intentional cancel).
- [ ] Click "Clear failed previews" — confirm dir is emptied and the banner disappears.
- [ ] `npm run clean:previews` — confirm dir is emptied.
- [ ] `curl -X DELETE http://localhost:3000/api/previews` — same.
- [ ] Save a real recording — confirm it still lands under `output/<name>-<timestamp>/` and plays back correctly.
- [ ] Delete a saved recording from the UI — confirm it goes away without errors (the old `.screencasts/` cleanup call was removed).