### PR TITLE
DEVREL-1416: Add the preview playground button back in

### DIFF
--- a/client/Sidebar/BlueprintPanel.jsx
+++ b/client/Sidebar/BlueprintPanel.jsx
@@ -7,6 +7,7 @@ import { blueprintToForm, useBlueprintFormState } from '../state/useBlueprintFor
 import { useSlugNameResolver } from '../state/useSlugNameResolver.js';
 import { errorMessage } from '../utils/actions.js';
 import { api } from '../utils/api.js';
+import { usePreviewBlueprintMutation } from '../utils/apiHooks.js';
 import { EnvironmentSection } from '../blueprint/EnvironmentSection.jsx';
 import { SiteSettingsSection } from '../blueprint/SiteSettingsSection.jsx';
 import { SlugListSection } from '../blueprint/SlugListSection.jsx';
@@ -19,6 +20,8 @@ export function BlueprintPanel() {
 
   const [isApplying, setIsApplying] = useState(false);
   const [resetDialogOpen, setResetDialogOpen] = useState(false);
+  const previewBlueprintMutation = usePreviewBlueprintMutation();
+  const isPreviewing = previewBlueprintMutation.isPending;
   const [pluginNames, learnPluginName] = useSlugNameResolver(formState.plugins, api.getPluginInfo);
   const [themeNames, learnThemeName] = useSlugNameResolver(formState.themes, api.getThemeInfo);
 
@@ -68,6 +71,25 @@ export function BlueprintPanel() {
     }
   }
 
+  async function handlePreview() {
+    const previewWindow = window.open('/preview-loading.html', '_blank');
+    if (previewWindow) previewWindow.opener = null;
+
+    try {
+      const data = await previewBlueprintMutation.mutateAsync(compiledBlueprint);
+      if (!data?.url) throw new Error('Preview URL missing');
+
+      if (previewWindow) {
+        previewWindow.location.replace(data.url);
+      } else {
+        window.open(data.url, '_blank', 'noopener,noreferrer');
+      }
+    } catch (err) {
+      previewWindow?.close();
+      toast.error(errorMessage(err, 'Could not preview blueprint'));
+    }
+  }
+
   return (
     <>
     <div className="tab-panel-body">
@@ -107,9 +129,17 @@ export function BlueprintPanel() {
     <div className="tab-panel-footer">
       <button
         type="button"
+        className={clsx('bp-action-btn bp-action-btn--ghost bp-action-btn--preview', isPreviewing && 'is-loading')}
+        onClick={handlePreview}
+        disabled={isPreviewing || isApplying}
+      >
+        Preview
+      </button>
+      <button
+        type="button"
         className="bp-action-btn bp-action-btn--ghost"
         onClick={openResetDialog}
-        disabled={!defaultBlueprint || isAtDefault || isApplying}
+        disabled={!defaultBlueprint || isAtDefault || isApplying || isPreviewing}
       >
         Reset
       </button>
@@ -117,7 +147,7 @@ export function BlueprintPanel() {
         type="button"
         className={clsx('bp-action-btn bp-action-btn--primary', isApplying && 'is-loading')}
         onClick={handleApply}
-        disabled={isApplying || !hasUnappliedChanges}
+        disabled={isApplying || isPreviewing || !hasUnappliedChanges}
       >
         Apply
       </button>

--- a/public/style.css
+++ b/public/style.css
@@ -1678,6 +1678,14 @@ header p {
   color: #e2e8f0;
 }
 
+.Toastify__toast-container {
+  --toastify-color-progress-dark: #6366f1;
+  --toastify-color-progress-info: #6366f1;
+  --toastify-color-progress-success: #6366f1;
+  --toastify-color-progress-warning: #6366f1;
+  --toastify-color-progress-error: #6366f1;
+}
+
 /* ── Recordings section ─────────────────────────────────── */
 
 #recordings-section {

--- a/public/style.css
+++ b/public/style.css
@@ -306,6 +306,29 @@ header p {
   color: #e2e8f0;
 }
 
+.bp-action-btn--preview {
+  margin-right: auto;
+}
+
+.bp-action-btn.is-loading {
+  animation: bp-action-stripes 1.2s linear infinite;
+  background-image: linear-gradient(
+    135deg,
+    var(--bp-action-loading-stripe, rgba(255, 255, 255, 0.18)) 25%,
+    transparent 25%,
+    transparent 50%,
+    var(--bp-action-loading-stripe, rgba(255, 255, 255, 0.18)) 50%,
+    var(--bp-action-loading-stripe, rgba(255, 255, 255, 0.18)) 75%,
+    transparent 75%,
+    transparent
+  );
+  background-size: 48px 48px;
+}
+
+.bp-action-btn--ghost.is-loading {
+  --bp-action-loading-stripe: rgba(255, 255, 255, 0.12);
+}
+
 .bp-action-btn--primary {
   background: #6366f1;
   border: 1px solid transparent;
@@ -313,21 +336,6 @@ header p {
 }
 
 .bp-action-btn--primary:hover:not(:disabled) { background: #4f46e5; }
-
-.bp-action-btn--primary.is-loading {
-  animation: bp-action-stripes 1.2s linear infinite;
-  background-image: linear-gradient(
-    135deg,
-    rgba(255, 255, 255, 0.18) 25%,
-    transparent 25%,
-    transparent 50%,
-    rgba(255, 255, 255, 0.18) 50%,
-    rgba(255, 255, 255, 0.18) 75%,
-    transparent 75%,
-    transparent
-  );
-  background-size: 48px 48px;
-}
 
 @keyframes bp-action-stripes {
   from { background-position: 0 0; }

--- a/server.js
+++ b/server.js
@@ -28,9 +28,11 @@ const {
 } = require('./server/config');
 
 const app = express();
+const previewLoadingPage = path.join(__dirname, 'server/public/preview-loading.html');
 
 app.use(express.json());
 app.use('/screencasts', express.static(SCREENCASTS_DIR));
+app.get('/preview-loading.html', (req, res) => res.sendFile(previewLoadingPage));
 
 // Route modules — each registers its own handlers on `app`.
 require('./server/routes/translate').register(app);

--- a/server/public/preview-loading.html
+++ b/server/public/preview-loading.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Loading Playground preview</title>
+    <style>
+      *, *::before, *::after { box-sizing: border-box; }
+
+      body {
+        align-items: center;
+        background: #0f1117;
+        color: #e2e8f0;
+        display: flex;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        justify-content: center;
+        margin: 0;
+        min-height: 100vh;
+      }
+
+      main {
+        background: #111827;
+        border: 1px solid #1e2433;
+        border-radius: 8px;
+        padding: 1.5rem;
+        width: min(420px, calc(100vw - 2rem));
+      }
+
+      h1 {
+        font-size: 1rem;
+        line-height: 1.35;
+        margin: 0 0 0.45rem;
+      }
+
+      p {
+        color: #94a3b8;
+        font-size: 0.86rem;
+        line-height: 1.45;
+        margin: 0;
+      }
+
+      .bar {
+        background: #1a2035;
+        border-radius: 999px;
+        height: 0.35rem;
+        margin-top: 1rem;
+        overflow: hidden;
+      }
+
+      .bar::before {
+        animation: loading 1s ease-in-out infinite;
+        background: #6366f1;
+        content: "";
+        display: block;
+        height: 100%;
+        width: 40%;
+      }
+
+      @keyframes loading {
+        0% { transform: translateX(-100%); }
+        100% { transform: translateX(260%); }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Loading Playground preview</h1>
+      <p>Starting a WordPress Playground instance with the current blueprint.</p>
+      <div class="bar" aria-hidden="true"></div>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
Clicking the Preview button now immediately opens a new window (to work around browser popup block logic) which displays this loading screen:
<img width="599" height="347" alt="Screenshot 2026-05-14 at 13 43 55" src="https://github.com/user-attachments/assets/4a67085d-2121-4109-87d7-80876e8b721a" />

And here's the button:
<img width="888" height="395" alt="Screenshot 2026-05-14 at 15 24 17" src="https://github.com/user-attachments/assets/41e53c28-89e0-4139-8b27-7d746d02e734" />

When the playground instance is ready, the window will be redirected to it automatically.

PS:
This PR also sneaks in a more appropriately styled toastify progressbar 😁 