### PR TITLE
DEVREL-1425: Add an edit option to directions

### DIFF
--- a/client/DirectionGroup.jsx
+++ b/client/DirectionGroup.jsx
@@ -1,11 +1,14 @@
 import clsx from 'clsx';
+import { useEffect, useRef } from 'react';
 import { describePlain } from './utils/actions.js';
 
 export function DirectionGroup({
   direction,
   dragging,
   dragOver,
+  editValue = '',
   index,
+  isEditing,
   isAlwaysRun,
   isActiveStep,
   isSkipped,
@@ -16,6 +19,9 @@ export function DirectionGroup({
   onDragOver,
   onDragStart,
   onDrop,
+  onEditCancel,
+  onEditChange,
+  onEditSubmit,
   onLabelChange,
   onMenu,
   onToggleAlwaysRun,
@@ -36,14 +42,23 @@ export function DirectionGroup({
     isAlwaysRun && 'always-run',
     isTranslating && 'is-translating',
     isTranslationError && 'has-translation-error',
+    isEditing && 'is-editing',
   );
+  const editInputRef = useRef(null);
+
+  useEffect(() => {
+    if (isEditing) {
+      editInputRef.current?.focus();
+      editInputRef.current?.select();
+    }
+  }, [isEditing]);
 
   return (
     <li
       ref={itemRef}
       className={className}
       aria-busy={isTranslating}
-      draggable={isResolved}
+      draggable={isResolved && !isEditing}
       onDragStart={onDragStart}
       onDragEnd={onDragEnd}
       onDragOver={onDragOver}
@@ -57,7 +72,7 @@ export function DirectionGroup({
           className="direction-label-input"
           value={direction.label}
           title="Edit label"
-          disabled={!isResolved}
+          disabled={!isResolved || isEditing}
           onChange={(event) => onLabelChange(event.target.value)}
           onDragStart={(event) => event.preventDefault()}
         />
@@ -65,7 +80,7 @@ export function DirectionGroup({
           className="direction-start-btn"
           title={isStartFrom ? 'Clear preview start point' : 'Preview from this step'}
           type="button"
-          disabled={!isResolved}
+          disabled={!isResolved || isEditing}
           onClick={onToggleStartFrom}
         >
           &#9655;
@@ -74,15 +89,48 @@ export function DirectionGroup({
           className="direction-pin-btn"
           title={isAlwaysRun ? 'Remove always-run' : 'Always run (even when skipping earlier steps)'}
           type="button"
-          disabled={!isResolved}
+          disabled={!isResolved || isEditing}
           onClick={onToggleAlwaysRun}
         >
           &#128204;
         </button>
-        <button className="direction-menu-btn" title="More actions" type="button" onClick={onMenu}>
+        <button className="direction-menu-btn" title="More actions" type="button" disabled={!isResolved || isEditing} onClick={onMenu}>
           &#8943;
         </button>
       </div>
+
+      {isEditing && isResolved && (
+        <form
+          className="direction-edit-form"
+          onSubmit={(event) => {
+            event.preventDefault();
+            onEditSubmit();
+          }}
+        >
+          <input
+            ref={editInputRef}
+            className="direction-edit-input"
+            type="text"
+            value={editValue}
+            aria-label="Additional context for this direction"
+            placeholder="Tell AI what to change or clarify..."
+            onChange={(event) => onEditChange(event.target.value)}
+            onDragStart={(event) => event.preventDefault()}
+            onKeyDown={(event) => {
+              if (event.key === 'Escape') {
+                event.preventDefault();
+                onEditCancel();
+              }
+            }}
+          />
+          <button className="direction-edit-btn direction-edit-btn--secondary" type="button" onClick={onEditCancel}>
+            Cancel
+          </button>
+          <button className="direction-edit-btn direction-edit-btn--primary" type="submit" disabled={!editValue.trim()}>
+            Send
+          </button>
+        </form>
+      )}
 
       {isTranslating && (
         <div className="direction-translation-state">

--- a/client/DirectionMenu.jsx
+++ b/client/DirectionMenu.jsx
@@ -1,3 +1,49 @@
+import { TrashIcon } from './Sidebar/TrashIcon.jsx';
+
+const MENU_ICONS = {
+  edit: (
+    <>
+      <path d="M4 20h4l10.5-10.5a2.12 2.12 0 0 0-3-3L5 17l-1 3Z" />
+      <path d="m14 7 3 3" />
+    </>
+  ),
+  insert: (
+    <>
+      <path d="M12 5v14" />
+      <path d="M5 12h14" />
+    </>
+  ),
+  save: (
+    <>
+      <path d="M5 4h11l3 3v13H5Z" />
+      <path d="M8 4v6h8" />
+      <path d="M8 20v-6h8v6" />
+    </>
+  ),
+  stepsHidden: (
+    <>
+      <path d="M2.5 12s3.5-6 9.5-6 9.5 6 9.5 6-3.5 6-9.5 6-9.5-6-9.5-6Z" />
+      <circle cx="12" cy="12" r="3" />
+    </>
+  ),
+  stepsShown: (
+    <>
+      <path d="m4 4 16 16" />
+      <path d="M9.5 5.3A9.6 9.6 0 0 1 12 5c6 0 9.5 7 9.5 7a17.8 17.8 0 0 1-2.6 3.4" />
+      <path d="M14.1 14.1A3 3 0 0 1 9.9 9.9" />
+      <path d="M6.6 6.6A17.7 17.7 0 0 0 2.5 12s3.5 7 9.5 7a9.5 9.5 0 0 0 4.8-1.4" />
+    </>
+  ),
+};
+
+function MenuIcon({ name }) {
+  return (
+    <svg className="recording-action-icon direction-menu-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true" focusable="false">
+      {MENU_ICONS[name]}
+    </svg>
+  );
+}
+
 export function DirectionMenu({ direction, onClose, onDelete, onEdit, onInsert, onSave, onToggle, position }) {
   if (!position) return null;
   const isResolved = !direction._translation?.status || direction._translation.status === 'resolved';
@@ -14,25 +60,30 @@ export function DirectionMenu({ direction, onClose, onDelete, onEdit, onInsert, 
     <div className="direction-menu" style={{ top: position.top, left: position.left }} onClick={(event) => event.stopPropagation()}>
       {isResolved && (
         <button className="direction-menu-item direction-menu-toggle" type="button" onClick={handleClick(onToggle)}>
-          {direction._open ? '\u25B2 Hide steps' : '\u25BC Show steps'}
+          <MenuIcon name={direction._open ? 'stepsShown' : 'stepsHidden'} />
+          <span>{direction._open ? 'Hide steps' : 'Show steps'}</span>
         </button>
       )}
       <button className="direction-menu-item direction-menu-insert" type="button" onClick={handleClick(onInsert)}>
-        + Insert direction
+        <MenuIcon name="insert" />
+        <span>Insert direction</span>
       </button>
       {isResolved && !direction._fromDirection && (
         <button className="direction-menu-item direction-menu-save" type="button" onClick={handleClick(onSave)}>
-          &#128190; Save direction
+          <MenuIcon name="save" />
+          <span>Save direction</span>
         </button>
       )}
       {isResolved && (
         <button className="direction-menu-item direction-menu-edit" type="button" onClick={handleClick(onEdit)}>
-          Edit
+          <MenuIcon name="edit" />
+          <span>Edit</span>
         </button>
       )}
       <div className="direction-menu-divider" />
       <button className="direction-menu-item direction-menu-item--danger" type="button" onClick={handleClick(onDelete)}>
-        &#10005; Delete step
+        <TrashIcon className="recording-action-icon direction-menu-icon" />
+        <span>Delete step</span>
       </button>
     </div>
   );

--- a/client/DirectionMenu.jsx
+++ b/client/DirectionMenu.jsx
@@ -1,4 +1,4 @@
-export function DirectionMenu({ direction, onClose, onDelete, onInsert, onSave, onToggle, position }) {
+export function DirectionMenu({ direction, onClose, onDelete, onEdit, onInsert, onSave, onToggle, position }) {
   if (!position) return null;
   const isResolved = !direction._translation?.status || direction._translation.status === 'resolved';
 
@@ -23,6 +23,11 @@ export function DirectionMenu({ direction, onClose, onDelete, onInsert, onSave, 
       {isResolved && !direction._fromDirection && (
         <button className="direction-menu-item direction-menu-save" type="button" onClick={handleClick(onSave)}>
           &#128190; Save direction
+        </button>
+      )}
+      {isResolved && (
+        <button className="direction-menu-item direction-menu-edit" type="button" onClick={handleClick(onEdit)}>
+          Edit
         </button>
       )}
       <div className="direction-menu-divider" />

--- a/client/DirectionsPanel.jsx
+++ b/client/DirectionsPanel.jsx
@@ -13,6 +13,7 @@ import { directionsForJSON, errorMessage, flattenDirectionActions } from './util
 import {
   useDirectionLoader,
   useSaveDirectionMutation,
+  useTranslateMutation,
 } from './utils/apiHooks.js';
 import { useRunState } from './context/RunContext.jsx';
 
@@ -44,9 +45,12 @@ export function DirectionsPanel() {
     deleteDirection,
     directions,
     directionsView,
+    failPendingDirection,
     insertDirectionAt,
     libraryEntries,
     reorderDirections,
+    replaceWithPendingDirection,
+    resolvePendingDirection,
     setDirectionsView,
     startFromIndex,
     toggleAlwaysRun,
@@ -60,10 +64,12 @@ export function DirectionsPanel() {
   const [dragOverIndex, setDragOverIndex] = useState(null);
   const [menu, setMenu] = useState(null);
   const [picker, setPicker] = useState(null);
+  const [editDirection, setEditDirection] = useState(null);
   const [activeTab, setActiveTab] = useState('directions');
   const [clearDirectionsDialogOpen, setClearDirectionsDialogOpen] = useState(false);
   const loadDirection = useDirectionLoader();
   const saveDirectionMutation = useSaveDirectionMutation();
+  const translateMutation = useTranslateMutation();
 
   const closePopovers = useCallback(() => {
     setMenu(null);
@@ -103,6 +109,46 @@ export function DirectionsPanel() {
     } catch (err) {
       toast.error(errorMessage(err, 'Save failed'));
       return null;
+    }
+  }
+
+  function buildEditCommand(direction, context) {
+    return [
+      'Retranslate this existing direction using the user\'s additional context.',
+      'Treat the context as a clarification for the current direction, not as a standalone new direction.',
+      'Return replacement direction(s) for this direction only.',
+      `Current direction intent: ${direction.label}`,
+      `Current direction JSON:\n${JSON.stringify(directionsForJSON([direction])[0] ?? { label: direction.label, actions: direction.actions ?? [] }, null, 2)}`,
+      `User added context: ${context}`,
+    ].join('\n\n');
+  }
+
+  async function submitDirectionEdit(index) {
+    const direction = directions[index];
+    if (!direction) return;
+
+    const context = editDirection?.value?.trim();
+    if (!context) return;
+
+    const history = directionsForJSON(directions.slice(0, index)).flatMap((group) => group.actions ?? []);
+    const command = buildEditCommand(direction, context);
+    const pending = replaceWithPendingDirection(index, direction.label, context);
+    setEditDirection(null);
+    if (!pending) return;
+
+    try {
+      const data = await translateMutation.mutateAsync({ command, history });
+      const translatedDirections = data.directions ?? [];
+
+      if (!translatedDirections.length) {
+        throw new Error('Translation returned no directions');
+      }
+
+      const nextDirections = resolvePendingDirection(pending._id, translatedDirections, context, index);
+      toast.success(nextDirections.length === 1 ? 'Updated direction' : `Updated ${nextDirections.length} directions`);
+    } catch (err) {
+      failPendingDirection(pending._id, err);
+      toast.error(errorMessage(err, 'Edit failed'));
     }
   }
 
@@ -193,7 +239,9 @@ export function DirectionsPanel() {
                         direction={direction}
                         dragging={draggingIndex === index}
                         dragOver={dragOverIndex === index}
+                        editValue={editDirection?.index === index ? editDirection.value : ''}
                         index={index}
+                        isEditing={editDirection?.index === index}
                         isAlwaysRun={isAlwaysRun}
                         isActiveStep={activeStepIndex === index}
                         isSkipped={isSkipped}
@@ -234,6 +282,11 @@ export function DirectionsPanel() {
                           setDraggingIndex(null);
                           setDragOverIndex(null);
                         }}
+                        onEditCancel={() => setEditDirection(null)}
+                        onEditChange={(value) => setEditDirection((current) => (
+                          current?.index === index ? { ...current, value } : current
+                        ))}
+                        onEditSubmit={() => submitDirectionEdit(index)}
                         onLabelChange={(label) => updateDirectionLabel(index, label)}
                         onMenu={(event) => {
                           event.stopPropagation();
@@ -310,6 +363,9 @@ export function DirectionsPanel() {
             position={menu.position}
             onClose={() => setMenu(null)}
             onDelete={() => deleteDirection(menu.index)}
+            onEdit={() => {
+              setEditDirection({ index: menu.index, value: '' });
+            }}
             onInsert={() => setPicker({ anchorIndex: menu.index, position: menu.position })}
             onSave={() => saveDirection(menu.index)}
             onToggle={() => toggleDirectionOpen(menu.index)}

--- a/client/Sidebar/TrashIcon.jsx
+++ b/client/Sidebar/TrashIcon.jsx
@@ -1,6 +1,6 @@
-export function TrashIcon() {
+export function TrashIcon({ className = 'recording-action-icon' }) {
   return (
-    <svg className="recording-action-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none">
+    <svg className={className} aria-hidden="true" viewBox="0 0 24 24" fill="none">
       <path d="M4 7h16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
       <path d="M10 11v6m4-6v6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
       <path d="M6 7l1 14h10l1-14M9 7V4h6v3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />

--- a/client/state/useDirectionsState.js
+++ b/client/state/useDirectionsState.js
@@ -13,9 +13,9 @@ function remapMovedIndex(index, from, to) {
   return index;
 }
 
-function pendingDirection(command) {
+function pendingDirection(command, label = command) {
   return withDirectionId({
-    label: command,
+    label,
     actions: [],
     _translation: {
       status: 'pending',
@@ -71,11 +71,32 @@ export function useDirectionsState() {
     return direction;
   }, []);
 
-  const resolvePendingDirection = useCallback((id, raw, command) => {
+  const replaceWithPendingDirection = useCallback((index, label, command) => {
+    if (index < 0 || index >= directions.length) return null;
+
+    const direction = pendingDirection(command, label);
+    setDirections((current) => current.map((item, i) => (
+      i === index ? direction : item
+    )));
+    return direction;
+  }, [directions.length]);
+
+  const resolvePendingDirection = useCallback((id, raw, command, replaceIndex = null) => {
     const nextDirections = translatedDirections(raw, command);
+    const delta = nextDirections.length - 1;
+
     setDirections((current) => current.flatMap((direction) => (
       direction._id === id ? nextDirections : [direction]
     )));
+
+    if (replaceIndex != null && delta !== 0) {
+      setStartFromIndex((current) => {
+        if (current == null || current <= replaceIndex) return current;
+        return current + delta;
+      });
+      setAlwaysRunIndices((current) => new Set([...current].map((i) => (i > replaceIndex ? i + delta : i))));
+    }
+
     return nextDirections;
   }, []);
 
@@ -176,6 +197,7 @@ export function useDirectionsState() {
     replaceDirections,
     appendDirections,
     appendPendingDirection,
+    replaceWithPendingDirection,
     resolvePendingDirection,
     failPendingDirection,
     clearDirections,

--- a/public/style.css
+++ b/public/style.css
@@ -1415,8 +1415,8 @@ header p {
   border: 1px solid #2d3a50;
   border-radius: 6px;
   box-shadow: 0 4px 16px rgba(0,0,0,0.4);
-  min-width: 180px;
-  padding: 0.3rem 0;
+  min-width: 190px;
+  padding: 0.35rem 0;
 }
 
 .popover-backdrop {
@@ -1430,15 +1430,18 @@ header p {
 }
 
 .direction-menu-item {
+  align-items: center;
   background: none;
   border: none;
   color: #cbd5e1;
   cursor: pointer;
-  display: block;
+  display: flex;
   font-size: 0.85rem;
-  padding: 0.45rem 1rem;
+  gap: 0.7rem;
+  line-height: 1.2;
+  padding: 0.5rem 0.85rem;
   text-align: left;
-  transition: background 0.1s;
+  transition: background 0.1s, color 0.1s;
   white-space: nowrap;
   width: 100%;
 }
@@ -1446,9 +1449,26 @@ header p {
 .direction-menu-item--danger { color: #f87171; }
 .direction-menu-item--danger:hover { background: #2d1f1f; }
 
+.direction-menu-icon {
+  color: currentColor;
+  flex: 0 0 auto;
+  height: 1.08rem;
+  opacity: 0.82;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+  transition: opacity 0.1s;
+  width: 1.08rem;
+}
+
+.direction-menu-item:hover .direction-menu-icon {
+  opacity: 1;
+}
+
 .direction-menu-divider {
   border-top: 1px solid #2d3a50;
-  margin: 0.3rem 0;
+  margin: 0.35rem 0;
 }
 
 .direction-group-header {

--- a/public/style.css
+++ b/public/style.css
@@ -1300,18 +1300,84 @@ header p {
 .direction-pin-btn:hover { color: #f59e0b; background: #1f1a0a; }
 .direction-menu-btn:hover { color: #94a3b8; background: #252d3d; }
 .direction-start-btn:disabled,
-.direction-pin-btn:disabled {
+.direction-pin-btn:disabled,
+.direction-menu-btn:disabled {
   color: #2d3748;
   cursor: not-allowed;
 }
 .direction-start-btn:disabled:hover,
-.direction-pin-btn:disabled:hover {
+.direction-pin-btn:disabled:hover,
+.direction-menu-btn:disabled:hover {
   background: transparent;
 }
 
 .direction-label-input:disabled {
   color: #94a3b8;
   cursor: default;
+}
+
+.direction-edit-form {
+  align-items: center;
+  border-top: 1px solid #24324a;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  padding: 0.55rem 0.75rem 0.65rem 3.2rem;
+}
+
+.direction-edit-input {
+  background: #111827;
+  border: 1px solid #374151;
+  border-radius: 5px;
+  color: #f8fafc;
+  font-size: 0.85rem;
+  min-width: 0;
+  outline: none;
+  padding: 0.42rem 0.55rem;
+  width: 100%;
+}
+
+.direction-edit-input:focus {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.18);
+}
+
+.direction-edit-btn {
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1.2;
+  padding: 0.42rem 0.7rem;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.direction-edit-btn--secondary {
+  background: transparent;
+  border: 1px solid #374151;
+  color: #94a3b8;
+}
+
+.direction-edit-btn--secondary:hover {
+  border-color: #6b7280;
+  color: #e2e8f0;
+}
+
+.direction-edit-btn--primary {
+  background: #16a34a;
+  border: 1px solid transparent;
+  color: #fff;
+}
+
+.direction-edit-btn--primary:hover { background: #15803d; }
+
+.direction-edit-btn:disabled,
+.direction-edit-btn:disabled:hover {
+  background: #374151;
+  border-color: transparent;
+  color: #94a3b8;
+  cursor: not-allowed;
 }
 
 .direction-translation-state {

--- a/recordings/run-steps.js
+++ b/recordings/run-steps.js
@@ -368,6 +368,17 @@ async function runStep(step, page, frameStack, ctx, sidebar, settings = { typing
         `#adminmenu .wp-submenu li a:text-is("${step.item}")`
       ).first();
       const topCount = await topLevel.count();
+      const subCount = await subLevel.count();
+
+      if ( topCount === 0 && subCount > 0 ) {
+        const parentMenuItem = page
+          .locator('#adminmenu > li')
+          .filter({ has: page.locator(`.wp-submenu li a:text-is("${step.item}")`) })
+          .locator('> a')
+          .first();
+        await parentMenuItem.hover();
+      }
+
       const menuLink = topCount > 0 ? topLevel : subLevel;
       await highlightAndClick(page, menuLink);
       await page.waitForLoadState('domcontentloaded');

--- a/server/claude.js
+++ b/server/claude.js
@@ -93,6 +93,7 @@ After navigating to new-post or new-page, always emit \`tryClick\` with \`role: 
   After \`wpAdminMenuClick\`, always emit \`waitForSelector\` on a landmark element of the destination page (e.g. \`#wpbody\`).
   Exception: \`"Add Post"\` and \`"Add Page"\` land in the block editor — do NOT use \`waitForSelector: "#wpbody"\` for those items because \`#wpbody\` may be hidden by fullscreen mode depending on user preferences or blueprint configuration. Use \`waitForSelector\` with \`[aria-label="Editor top bar"]\` instead, which is always present regardless of fullscreen state. For \`"Add Page"\`, also emit \`tryClick\` with \`role: "button"\`, \`name: "Close"\`, and \`timeout: 5000\` after the waitForSelector, to dismiss the pattern chooser dialog that may appear.
   Exception: \`"Theme File Editor"\` and \`"Plugin File Editor"\` may show a security warning overlay — emit \`tryClick\` with selector \`#file-editor-warning .file-editor-warning-dismiss\` and \`timeout: 5000\` immediately after the \`wpAdminMenuClick\` (it silently skips if the warning was suppressed via blueprint), then emit \`waitForSelector: "#wpbody"\`.
+  When clicking a submenu item, never click the parent menu parent item as a preceding step, unless the submenu item is not shown without clicking the parent item first. Instead, execute a hover action on the parent item first.
 
   **Exact admin menu labels** — use these verbatim, including capitalisation:
 
@@ -230,7 +231,8 @@ After navigating to new-post or new-page, always emit \`tryClick\` with \`role: 
 - To open any panel's options (⋮) menu, ALWAYS use wpOpenOptionsMenu — never use highlightClick on an options button; highlightClick is a toggle and will close the menu if it is already open
 - When enabling multiple controls from the same panel's options menu, open the options button ONCE and click all menuitemcheckbox items in sequence — never click the options button again between items (it toggles the menu closed); group all of them in one direction
 - Never invent action types — only use the actions listed above
-- Each direction should contain ONLY the actions required to accomplish its stated intent — do NOT add setup steps (opening the sidebar, selecting a block, switching tabs, etc.) that a prior direction may have already handled. Assume the UI is in the state the prior directions left it in. For example, if the user just selected a block, the sidebar is already open on the Block tab — do not emit steps to open Settings or click the Block tab again`;
+- Each direction should contain ONLY the actions required to accomplish its stated intent — do NOT add setup steps (opening the sidebar, selecting a block, switching tabs, etc.) that a prior direction may have already handled. Assume the UI is in the state the prior directions left it in. For example, if the user just selected a block, the sidebar is already open on the Block tab — do not emit steps to open Settings or click the Block tab again
+- Limit the number of steps in a single directions to no more than 5. Make sure the steps within a direction only pertain to that direction. If the direction covers more than one intent or needs more than 5 steps, split the direction into multiple ones.`;
 
 /**
  * Tool schema for forced structured output. We pass this plus `tool_choice:


### PR DESCRIPTION
This new option allows the user to input a prompt that, combined with the old label and steps, is translated into new steps.

<img width="263" height="248" alt="Screenshot 2026-05-16 at 17 12 53" src="https://github.com/user-attachments/assets/2da89e08-1780-42e2-8d0f-d3e9812be254" />

<img width="1071" height="167" alt="Screenshot 2026-05-16 at 17 12 43" src="https://github.com/user-attachments/assets/ab87c5e7-4702-48b4-8dfc-979678983c86" />

This PR also reworks the direction dropdown icons to better match the general style.