### PR TITLE
DEVREL-1430: Replace record/preview with a single play button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,6 @@ blueprints/blueprint.preview.json
 scripts/*.json
 /directions/*
 !/directions/.gitkeep
-/public/screencasts/*
-!/public/screencasts/.gitkeep
 .DS_Store
 plans/
 prd/

--- a/client/DirectionGroup.jsx
+++ b/client/DirectionGroup.jsx
@@ -63,7 +63,7 @@ export function DirectionGroup({
         />
         <button
           className="direction-start-btn"
-          title={isStartFrom ? 'Clear preview start point' : 'Preview from this step'}
+          title={isStartFrom ? 'Clear play start point' : 'Play from this step'}
           type="button"
           disabled={!isResolved}
           onClick={onToggleStartFrom}

--- a/client/DirectionToolbar.jsx
+++ b/client/DirectionToolbar.jsx
@@ -66,20 +66,16 @@ export function DirectionToolbar() {
     URL.revokeObjectURL(link.href);
   }
 
-  async function handleRun(preview, scriptName) {
+  async function handlePlay() {
     try {
-      await runActions({ preview, scriptName });
+      await runActions();
     } catch {
       // The run context already surfaces the failure through a toast.
     }
   }
 
   function executeNamedAction(action, scriptName) {
-    if (action === 'record') {
-      handleRun(false, scriptName);
-    } else if (action === 'preview') {
-      handleRun(true, scriptName);
-    } else if (action === 'save') {
+    if (action === 'save') {
       saveScript(scriptName);
     } else if (action === 'export') {
       exportTxt(scriptName);
@@ -131,10 +127,10 @@ export function DirectionToolbar() {
             className="primary"
             type="button"
             disabled={!hasResolvedDirections}
-            title={poolLabel ?? (startFromIndex !== null ? 'Record full script (preview start point ignored)' : 'Record')}
-            onClick={() => runWithScriptName('record')}
+            title={poolLabel ?? (startFromIndex !== null ? 'Play from preview start point' : 'Play')}
+            onClick={handlePlay}
           >
-            &#9654; Record
+            &#9654; Play
           </button>
         )}
 
@@ -144,17 +140,6 @@ export function DirectionToolbar() {
           </button>
         )}
 
-        {!running && (
-          <button
-            className="secondary"
-            type="button"
-            disabled={!hasResolvedDirections}
-            title={poolLabel ?? 'Preview'}
-            onClick={() => runWithScriptName('preview')}
-          >
-            &#9654; Preview
-          </button>
-        )}
       </div>
 
       {pendingNamedAction && (

--- a/client/PreviewPanel.jsx
+++ b/client/PreviewPanel.jsx
@@ -1,28 +1,73 @@
 import clsx from 'clsx';
+import { useState } from 'react';
+import { toast } from 'react-toastify';
+import { useAppState } from './context/AppStateContext.jsx';
 import { useRunState } from './context/RunContext.jsx';
+import { errorMessage } from './utils/actions.js';
+import { useSaveLatestPreviewMutation } from './utils/apiHooks.js';
 import { formatTimestamp } from './utils/formatters.js';
 
 export function PreviewPanel() {
-  const { preview } = useRunState();
+  const { loadRecordings, name } = useAppState();
+  const { preview, running, showPreviewVideo } = useRunState();
+  const savePreviewMutation = useSaveLatestPreviewMutation();
+  const [savingPreview, setSavingPreview] = useState(false);
   const isPolling = preview.mode === 'connecting' || (preview.mode === 'image' && preview.isLive);
-  const heading = preview.mode === 'video' && preview.title ? `Recording: ${preview.title}` : 'Live Preview';
+  const heading = preview.mode === 'video' && preview.title
+    ? `${preview.saveable ? 'Playback' : 'Recording'}: ${preview.title}`
+    : 'Live Preview';
   const connectingLabel = preview.playgroundPort
     ? `Connecting to browser on port ${preview.playgroundPort}...`
     : 'Connecting to browser...';
   const recordingTimestamp = preview.mode === 'video' && preview.title
     ? formatTimestamp(preview.recordedAt)
     : null;
+  const canSavePreview = preview.mode === 'video' && preview.saveable && !running;
+
+  async function savePreviewVideo() {
+    const fallbackName = preview.title || `recording-${Date.now()}`;
+    const saveName = name.trim() || fallbackName;
+
+    setSavingPreview(true);
+    try {
+      const saved = await savePreviewMutation.mutateAsync({
+        name: saveName,
+      });
+      loadRecordings();
+      showPreviewVideo(saved.videoUrl, {
+        recordedAt: saved.createdAt,
+        title: saved.name,
+        saveable: false,
+      });
+      toast.success(`Saved video "${saved.name}"`);
+    } catch (err) {
+      toast.error(errorMessage(err, 'Could not save video'));
+    } finally {
+      setSavingPreview(false);
+    }
+  }
 
   return (
     <div className={clsx('panel', isPolling && 'polling')} id="preview-panel">
       <div className="preview-heading">
         <h2>{heading}</h2>
-        {recordingTimestamp && <span className="preview-heading-timestamp">{recordingTimestamp}</span>}
+        {canSavePreview ? (
+          <button
+            className="preview-save-btn"
+            type="button"
+            disabled={savingPreview}
+            onClick={savePreviewVideo}
+          >
+            {savingPreview ? 'Saving...' : 'Save Recording'}
+          </button>
+        ) : (
+          recordingTimestamp && <span className="preview-heading-timestamp">{recordingTimestamp}</span>
+        )}
       </div>
       <div id="preview-container">
         {(preview.mode === 'idle' || preview.mode === 'connecting') && (
           <div id="preview-placeholder">
-            {preview.mode === 'connecting' ? connectingLabel : 'No preview yet - start a recording to see the browser live.'}
+            {preview.mode === 'connecting' ? connectingLabel : 'No video yet - press Play to see the browser live.'}
           </div>
         )}
 

--- a/client/ScriptNameDialog.jsx
+++ b/client/ScriptNameDialog.jsx
@@ -6,14 +6,6 @@ const ACTION_COPY = {
     confirmLabel: 'Export TXT',
     description: 'Enter a script name before exporting the current script.',
   },
-  preview: {
-    confirmLabel: 'Preview',
-    description: 'Enter a script name before previewing the current script.',
-  },
-  record: {
-    confirmLabel: 'Record',
-    description: 'Enter a script name before recording the current script.',
-  },
   save: {
     confirmLabel: 'Save Script',
     description: 'Enter a script name before saving the current script.',

--- a/client/Sidebar/RecordingSettingsPanel.jsx
+++ b/client/Sidebar/RecordingSettingsPanel.jsx
@@ -40,7 +40,7 @@ export function RecordingSettingsPanel() {
     <div className="tab-panel-body">
       <div className="setting-field">
         <div className="setting-field-header">
-          <label htmlFor="typing-delay-input">Typing speed</label>
+          <label htmlFor="typing-delay-input">Typing delay</label>
           <span className="setting-field-value">{typingDelay} ms/char</span>
         </div>
         <input

--- a/client/Sidebar/RecordingsPanel.jsx
+++ b/client/Sidebar/RecordingsPanel.jsx
@@ -5,7 +5,7 @@ import { useAppState } from '../context/AppStateContext.jsx';
 import { useRunState } from '../context/RunContext.jsx';
 import { errorMessage } from '../utils/actions.js';
 import { formatFileSize, formatTimestamp } from '../utils/formatters.js';
-import { useDeleteRecordingMutation } from '../utils/apiHooks.js';
+import { useDeleteRecordingMutation, usePreviewsQuery, useClearPreviewsMutation } from '../utils/apiHooks.js';
 import { SectionBadge } from './SectionBadge.jsx';
 import { TrashIcon } from './TrashIcon.jsx';
 
@@ -30,8 +30,21 @@ export function RecordingsPanel() {
   const { recordings } = useAppState();
   const { running, showPreviewVideo } = useRunState();
   const deleteRecordingMutation = useDeleteRecordingMutation();
+  const previewsQuery = usePreviewsQuery();
+  const clearPreviewsMutation = useClearPreviewsMutation();
   const [pendingDeleteRecording, setPendingDeleteRecording] = useState(null);
   const deletingRecording = deleteRecordingMutation.isPending;
+  const failedPreviewCount = previewsQuery.data?.count ?? 0;
+  const clearingPreviews = clearPreviewsMutation.isPending;
+
+  async function clearFailedPreviews() {
+    try {
+      await clearPreviewsMutation.mutateAsync();
+      toast.success(`Cleared ${failedPreviewCount} failed preview${failedPreviewCount === 1 ? '' : 's'}`);
+    } catch (err) {
+      toast.error(errorMessage(err, 'Could not clear previews'));
+    }
+  }
 
   function closeDeleteDialog() {
     if (!deletingRecording) setPendingDeleteRecording(null);
@@ -58,6 +71,21 @@ export function RecordingsPanel() {
           <SectionBadge hidden={recordings.length === 0}>{recordings.length}</SectionBadge>
         </summary>
         <div className="recordings-body">
+          {failedPreviewCount > 0 && (
+            <div className="failed-previews-notice">
+              <span className="hint">
+                {failedPreviewCount} failed preview{failedPreviewCount === 1 ? '' : 's'} kept for debugging
+              </span>
+              <button
+                type="button"
+                className="app-dialog-btn app-dialog-btn--secondary"
+                disabled={clearingPreviews}
+                onClick={clearFailedPreviews}
+              >
+                {clearingPreviews ? 'Clearing...' : 'Clear failed previews'}
+              </button>
+            </div>
+          )}
           <div id="recordings-list">
             {!recordings.length && <p className="hint">No recordings yet - run a script to generate a video.</p>}
 

--- a/client/Sidebar/RecordingsPanel.jsx
+++ b/client/Sidebar/RecordingsPanel.jsx
@@ -5,7 +5,7 @@ import { useAppState } from '../context/AppStateContext.jsx';
 import { useRunState } from '../context/RunContext.jsx';
 import { errorMessage } from '../utils/actions.js';
 import { formatFileSize, formatTimestamp } from '../utils/formatters.js';
-import { useDeleteRecordingMutation, usePreviewsQuery, useClearPreviewsMutation } from '../utils/apiHooks.js';
+import { useDeleteRecordingMutation } from '../utils/apiHooks.js';
 import { SectionBadge } from './SectionBadge.jsx';
 import { TrashIcon } from './TrashIcon.jsx';
 
@@ -91,22 +91,9 @@ export function RecordingsPanel() {
   const { recordings } = useAppState();
   const { running, showPreviewVideo } = useRunState();
   const deleteRecordingMutation = useDeleteRecordingMutation();
-  const previewsQuery = usePreviewsQuery();
-  const clearPreviewsMutation = useClearPreviewsMutation();
   const [pendingDeleteRecording, setPendingDeleteRecording] = useState(null);
   const [downloadMenuFor, setDownloadMenuFor] = useState(null);
   const deletingRecording = deleteRecordingMutation.isPending;
-  const failedPreviewCount = previewsQuery.data?.count ?? 0;
-  const clearingPreviews = clearPreviewsMutation.isPending;
-
-  async function clearFailedPreviews() {
-    try {
-      await clearPreviewsMutation.mutateAsync();
-      toast.success(`Cleared ${failedPreviewCount} failed preview${failedPreviewCount === 1 ? '' : 's'}`);
-    } catch (err) {
-      toast.error(errorMessage(err, 'Could not clear previews'));
-    }
-  }
 
   function closeDeleteDialog() {
     if (!deletingRecording) setPendingDeleteRecording(null);
@@ -133,21 +120,6 @@ export function RecordingsPanel() {
           <SectionBadge hidden={recordings.length === 0}>{recordings.length}</SectionBadge>
         </summary>
         <div className="recordings-body">
-          {failedPreviewCount > 0 && (
-            <div className="failed-previews-notice">
-              <span className="hint">
-                {failedPreviewCount} failed preview{failedPreviewCount === 1 ? '' : 's'} kept for debugging
-              </span>
-              <button
-                type="button"
-                className="app-dialog-btn app-dialog-btn--secondary"
-                disabled={clearingPreviews}
-                onClick={clearFailedPreviews}
-              >
-                {clearingPreviews ? 'Clearing...' : 'Clear failed previews'}
-              </button>
-            </div>
-          )}
           <div id="recordings-list">
             {!recordings.length && <p className="hint">No recordings yet - run a script to generate a video.</p>}
 
@@ -168,8 +140,8 @@ export function RecordingsPanel() {
                     <button
                       className="recording-preview-btn recording-action-btn secondary"
                       type="button"
-                      aria-label={`Preview ${recording.name}`}
-                      title="Preview"
+                      aria-label={`Play ${recording.name}`}
+                      title="Play"
                       disabled={running}
                       onClick={() => showPreviewVideo(videoUrl, {
                         recordedAt: recording.createdAt,

--- a/client/context/RunContext.jsx
+++ b/client/context/RunContext.jsx
@@ -26,13 +26,14 @@ export function RunProvider({ children }) {
   const runLog = useRunLog();
   const runPreview = useRunPreview();
   const queryClient = useQueryClient();
+  const previewMessageHandler = runPreview.handlePreviewMessage;
   const handlePreviewMessage = useCallback((msg) => {
     if (msg.type === 'previewArtifact') {
       queryClient.invalidateQueries({ queryKey: queryKeys.previews });
       return;
     }
-    runPreview.handlePreviewMessage(msg);
-  }, [queryClient, runPreview]);
+    previewMessageHandler(msg);
+  }, [queryClient, previewMessageHandler]);
   const {
     activeStepIndex,
     running,

--- a/client/context/RunContext.jsx
+++ b/client/context/RunContext.jsx
@@ -1,9 +1,11 @@
-import { createContext, useContext, useMemo } from 'react';
+import { createContext, useCallback, useContext, useMemo } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useRunActions } from '../state/useRunActions.js';
 import { useRunLog } from '../state/useRunLog.js';
 import { useRunPreview } from '../state/useRunPreview.js';
 import { useRunStream } from '../state/useRunStream.js';
 import { useAppState } from './AppStateContext.jsx';
+import { queryKeys } from '../utils/api.js';
 
 const RunContext = createContext(null);
 
@@ -23,6 +25,14 @@ export function RunProvider({ children }) {
 
   const runLog = useRunLog();
   const runPreview = useRunPreview();
+  const queryClient = useQueryClient();
+  const handlePreviewMessage = useCallback((msg) => {
+    if (msg.type === 'previewArtifact') {
+      queryClient.invalidateQueries({ queryKey: queryKeys.previews });
+      return;
+    }
+    runPreview.handlePreviewMessage(msg);
+  }, [queryClient, runPreview]);
   const {
     activeStepIndex,
     running,
@@ -31,7 +41,7 @@ export function RunProvider({ children }) {
     stopRun,
   } = useRunStream({
     appendLog: runLog.appendLog,
-    handlePreviewMessage: runPreview.handlePreviewMessage,
+    handlePreviewMessage,
     markDone: runLog.markDone,
     markFailed: runLog.markFailed,
     markStopped: runLog.markStopped,

--- a/client/context/RunContext.jsx
+++ b/client/context/RunContext.jsx
@@ -1,11 +1,9 @@
 import { createContext, useCallback, useContext, useMemo } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
 import { useRunActions } from '../state/useRunActions.js';
 import { useRunLog } from '../state/useRunLog.js';
 import { useRunPreview } from '../state/useRunPreview.js';
 import { useRunStream } from '../state/useRunStream.js';
 import { useAppState } from './AppStateContext.jsx';
-import { queryKeys } from '../utils/api.js';
 
 const RunContext = createContext(null);
 
@@ -25,15 +23,10 @@ export function RunProvider({ children }) {
 
   const runLog = useRunLog();
   const runPreview = useRunPreview();
-  const queryClient = useQueryClient();
   const previewMessageHandler = runPreview.handlePreviewMessage;
   const handlePreviewMessage = useCallback((msg) => {
-    if (msg.type === 'previewArtifact') {
-      queryClient.invalidateQueries({ queryKey: queryKeys.previews });
-      return;
-    }
     previewMessageHandler(msg);
-  }, [queryClient, previewMessageHandler]);
+  }, [previewMessageHandler]);
   const {
     activeStepIndex,
     running,

--- a/client/state/useRunActions.js
+++ b/client/state/useRunActions.js
@@ -14,31 +14,28 @@ export function useRunActions({
   startRunRequest,
   streamRun,
 }) {
-  const runActions = useCallback(async ({ preview: previewOnly = false, scriptName } = {}) => {
+  const runActions = useCallback(async ({ scriptName } = {}) => {
     if (!runDirections.length) return;
 
-    const runName = scriptName?.trim() || name.trim() || `${previewOnly ? 'preview' : 'recording'}-${Date.now()}`;
+    const runName = scriptName?.trim() || name.trim() || `play-${Date.now()}`;
     const body = {
       name: runName,
       actions: runDirections,
       blueprint,
-      videoSize: previewOnly ? undefined : currentVideoSize,
-      preview: previewOnly || undefined,
-      endPause: previewOnly ? undefined : currentEndPause,
+      videoSize: currentVideoSize,
+      endPause: currentEndPause,
       stepPause: currentStepPause,
       typingDelay: currentTypingDelay,
     };
 
-    if (previewOnly && startFromIndex != null && startFromIndex > 0) {
+    if (startFromIndex != null && startFromIndex > 0) {
       body.startFrom = startFromIndex;
     }
 
     const { fetchPromise, controller } = startRunRequest('/api/run', body);
     await streamRun(fetchPromise, {
       controller,
-      onDone: (msg) => {
-        if (!msg.stopped && !previewOnly) loadRecordings();
-      },
+      onDone: () => {},
     });
   }, [
     blueprint,

--- a/client/state/useRunPreview.js
+++ b/client/state/useRunPreview.js
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 const IDLE_PREVIEW = {
   mode: 'idle',
@@ -12,29 +12,19 @@ const IDLE_PREVIEW = {
 };
 
 export function useRunPreview() {
-  const lastScreencastVideoRef = useRef('');
   const [preview, setPreview] = useState(IDLE_PREVIEW);
 
   const startPreview = useCallback(() => {
-    lastScreencastVideoRef.current = '';
     setPreview({ mode: 'connecting', imageSrc: '', recordedAt: null, videoSrc: '', poster: '', title: '', playgroundPort: null, isLive: false });
   }, []);
 
   const stopPreview = useCallback(() => {
-    const videoSrc = lastScreencastVideoRef.current;
     setPreview((current) => (
-      videoSrc
-        ? (
-          current.mode === 'video' && current.videoSrc === videoSrc
-            ? current
-            : { mode: 'video', imageSrc: '', recordedAt: null, videoSrc, poster: current.imageSrc, title: '', playgroundPort: null, isLive: false }
-        )
-        : (current.mode === 'image' ? { ...current, isLive: false, playgroundPort: null } : IDLE_PREVIEW)
+      current.mode === 'image' ? { ...current, isLive: false, playgroundPort: null } : IDLE_PREVIEW
     ));
   }, []);
 
   const showPreviewVideo = useCallback((videoSrc, { recordedAt = null, title = '' } = {}) => {
-    lastScreencastVideoRef.current = videoSrc;
     setPreview({ mode: 'video', imageSrc: '', recordedAt, videoSrc, poster: '', title, playgroundPort: null, isLive: false });
   }, []);
 
@@ -59,21 +49,6 @@ export function useRunPreview() {
         playgroundPort: null,
         isLive: true,
       });
-      return;
-    }
-
-    if (msg.type === 'screencastVideo') {
-      lastScreencastVideoRef.current = msg.uri;
-      setPreview((current) => ({
-        mode: 'video',
-        imageSrc: '',
-        recordedAt: null,
-        videoSrc: msg.uri,
-        poster: current.imageSrc,
-        title: '',
-        playgroundPort: null,
-        isLive: false,
-      }));
     }
   }, []);
 

--- a/client/state/useRunPreview.js
+++ b/client/state/useRunPreview.js
@@ -9,23 +9,41 @@ const IDLE_PREVIEW = {
   title: '',
   playgroundPort: null,
   isLive: false,
+  saveable: false,
 };
 
 export function useRunPreview() {
   const [preview, setPreview] = useState(IDLE_PREVIEW);
 
   const startPreview = useCallback(() => {
-    setPreview({ mode: 'connecting', imageSrc: '', recordedAt: null, videoSrc: '', poster: '', title: '', playgroundPort: null, isLive: false });
+    setPreview({ mode: 'connecting', imageSrc: '', recordedAt: null, videoSrc: '', poster: '', title: '', playgroundPort: null, isLive: false, saveable: false });
   }, []);
 
   const stopPreview = useCallback(() => {
     setPreview((current) => (
-      current.mode === 'image' ? { ...current, isLive: false, playgroundPort: null } : IDLE_PREVIEW
+      current.mode === 'image' || current.mode === 'video'
+        ? { ...current, isLive: false, playgroundPort: null }
+        : IDLE_PREVIEW
     ));
   }, []);
 
-  const showPreviewVideo = useCallback((videoSrc, { recordedAt = null, title = '' } = {}) => {
-    setPreview({ mode: 'video', imageSrc: '', recordedAt, videoSrc, poster: '', title, playgroundPort: null, isLive: false });
+  const showPreviewVideo = useCallback((videoSrc, { recordedAt = null, title = '', saveable = false } = {}) => {
+    setPreview({ mode: 'video', imageSrc: '', recordedAt, videoSrc, poster: '', title, playgroundPort: null, isLive: false, saveable });
+  }, []);
+
+  const showPlayableVideo = useCallback((video) => {
+    if (!video?.videoUrl) return;
+    setPreview({
+      mode: 'video',
+      imageSrc: '',
+      recordedAt: video.createdAt ?? null,
+      videoSrc: `${video.videoUrl}?t=${Date.now()}`,
+      poster: '',
+      title: video.name ?? 'Play',
+      playgroundPort: null,
+      isLive: false,
+      saveable: true,
+    });
   }, []);
 
   const handlePreviewMessage = useCallback((msg) => {
@@ -48,9 +66,20 @@ export function useRunPreview() {
         title: '',
         playgroundPort: null,
         isLive: true,
+        saveable: false,
       });
+      return;
     }
-  }, []);
+
+    if (msg.type === 'videoReady') {
+      showPlayableVideo(msg);
+      return;
+    }
+
+    if (msg.type === 'done' && msg.video) {
+      showPlayableVideo(msg.video);
+    }
+  }, [showPlayableVideo]);
 
   return {
     preview,

--- a/client/state/useRunStream.js
+++ b/client/state/useRunStream.js
@@ -93,8 +93,10 @@ export function useRunStream({
 
       await readSSE(res, (msg) => {
         if (runId !== runIdRef.current) return;
-        handleRunMessage(msg);
-        if (msg.type !== 'done') return;
+        if (msg.type !== 'done') {
+          handleRunMessage(msg);
+          return;
+        }
 
         receivedDone = true;
         clearRunAbortController(controller);
@@ -104,6 +106,7 @@ export function useRunStream({
         stopPreview();
         setRunning(false);
         setActiveStepIndex(null);
+        handlePreviewMessage(msg);
 
         if (msg.stopped) markStopped();
         else markDone(msg.code);
@@ -137,6 +140,7 @@ export function useRunStream({
     }
   }, [
     clearRunAbortController,
+    handlePreviewMessage,
     handleRunMessage,
     markDone,
     markFailed,

--- a/client/utils/api.js
+++ b/client/utils/api.js
@@ -69,6 +69,7 @@ export const queryKeys = {
   },
   recordings: ["recordings"],
   scripts: ["scripts"],
+  previews: ["previews"],
 };
 
 export const api = {
@@ -133,6 +134,15 @@ export const api = {
     return requestJSON(`/api/recordings/${encodeURIComponent(dirname)}`, {
       method: "DELETE",
     });
+  },
+
+  async listPreviews({ signal } = {}) {
+    const data = await requestJSON("/api/previews", { signal });
+    return { count: data?.count ?? 0, items: data?.items ?? [] };
+  },
+
+  async clearPreviews() {
+    return requestJSON("/api/previews", { method: "DELETE" });
   },
 
   async previewBlueprint(blueprint) {

--- a/client/utils/api.js
+++ b/client/utils/api.js
@@ -138,11 +138,15 @@ export const api = {
 
   async listPreviews({ signal } = {}) {
     const data = await requestJSON("/api/previews", { signal });
-    return { count: data?.count ?? 0, items: data?.items ?? [] };
+    return { count: data?.count ?? 0, items: data?.items ?? [], latest: data?.latest ?? null };
   },
 
   async clearPreviews() {
     return requestJSON("/api/previews", { method: "DELETE" });
+  },
+
+  async saveLatestPreview({ name }) {
+    return requestJSON("/api/previews/latest/save", postOptions({ name }));
   },
 
   async previewBlueprint(blueprint) {

--- a/client/utils/api.js
+++ b/client/utils/api.js
@@ -69,7 +69,6 @@ export const queryKeys = {
   },
   recordings: ["recordings"],
   scripts: ["scripts"],
-  previews: ["previews"],
 };
 
 export const api = {
@@ -134,15 +133,6 @@ export const api = {
     return requestJSON(`/api/recordings/${encodeURIComponent(dirname)}`, {
       method: "DELETE",
     });
-  },
-
-  async listPreviews({ signal } = {}) {
-    const data = await requestJSON("/api/previews", { signal });
-    return { count: data?.count ?? 0, items: data?.items ?? [], latest: data?.latest ?? null };
-  },
-
-  async clearPreviews() {
-    return requestJSON("/api/previews", { method: "DELETE" });
   },
 
   async saveLatestPreview({ name }) {

--- a/client/utils/apiHooks.js
+++ b/client/utils/apiHooks.js
@@ -69,6 +69,18 @@ export function useClearPreviewsMutation() {
   });
 }
 
+export function useSaveLatestPreviewMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: api.saveLatestPreview,
+    onSuccess: () => {
+      invalidate(queryClient, queryKeys.recordings);
+      return invalidate(queryClient, queryKeys.previews);
+    },
+  });
+}
+
 export function useDirectionLoader() {
   const queryClient = useQueryClient();
 

--- a/client/utils/apiHooks.js
+++ b/client/utils/apiHooks.js
@@ -51,33 +51,12 @@ export function useDeleteRecordingMutation() {
   });
 }
 
-export function usePreviewsQuery() {
-  return useQuery({
-    queryKey: queryKeys.previews,
-    queryFn: api.listPreviews,
-    staleTime: Infinity,
-    refetchOnWindowFocus: false,
-  });
-}
-
-export function useClearPreviewsMutation() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: api.clearPreviews,
-    onSuccess: () => invalidate(queryClient, queryKeys.previews),
-  });
-}
-
 export function useSaveLatestPreviewMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: api.saveLatestPreview,
-    onSuccess: () => {
-      invalidate(queryClient, queryKeys.recordings);
-      return invalidate(queryClient, queryKeys.previews);
-    },
+    onSuccess: () => invalidate(queryClient, queryKeys.recordings),
   });
 }
 

--- a/client/utils/apiHooks.js
+++ b/client/utils/apiHooks.js
@@ -51,6 +51,22 @@ export function useDeleteRecordingMutation() {
   });
 }
 
+export function usePreviewsQuery() {
+  return useQuery({
+    queryKey: queryKeys.previews,
+    queryFn: api.listPreviews,
+  });
+}
+
+export function useClearPreviewsMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: api.clearPreviews,
+    onSuccess: () => invalidate(queryClient, queryKeys.previews),
+  });
+}
+
 export function useDirectionLoader() {
   const queryClient = useQueryClient();
 

--- a/client/utils/apiHooks.js
+++ b/client/utils/apiHooks.js
@@ -55,6 +55,8 @@ export function usePreviewsQuery() {
   return useQuery({
     queryKey: queryKeys.previews,
     queryFn: api.listPreviews,
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "record:actions": "playwright test recordings/actions-runner.spec.js",
     "record:action": "playwright test recordings/actions-runner.spec.js --grep",
     "show-report": "playwright show-report",
-    "show-trace": "playwright show-trace"
+    "show-trace": "playwright show-trace",
+    "clean:previews": "rm -rf output/.previews"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",

--- a/public/style.css
+++ b/public/style.css
@@ -1703,22 +1703,6 @@ header p {
   padding: 0.75rem 1.5rem 1rem;
 }
 
-.failed-previews-notice {
-  align-items: center;
-  border: 1px solid #3b2f12;
-  background: #1a1408;
-  border-radius: 6px;
-  display: flex;
-  gap: 0.6rem;
-  justify-content: space-between;
-  margin-bottom: 0.6rem;
-  padding: 0.55rem 0.75rem;
-}
-
-.failed-previews-notice .hint {
-  margin: 0;
-}
-
 .recording-item {
   align-items: center;
   border-bottom: 1px solid #1a2035;
@@ -1983,14 +1967,16 @@ header p {
 }
 
 .preview-heading {
-  align-items: baseline;
+  align-items: center;
   display: flex;
   gap: 1rem;
+  min-height: 1.65rem;
   justify-content: space-between;
   margin-bottom: 0.75rem;
 }
 
 .preview-heading h2 {
+  line-height: 1.65rem;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;
@@ -2002,6 +1988,33 @@ header p {
   color: #475569;
   flex-shrink: 0;
   font-size: 0.75rem;
+}
+
+.preview-save-btn {
+  background: transparent;
+  border: 1px solid #374151;
+  border-radius: 6px;
+  color: #94a3b8;
+  cursor: pointer;
+  flex-shrink: 0;
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1;
+  min-height: 1.65rem;
+  padding: 0 0.7rem;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.preview-save-btn:hover {
+  border-color: #6b7280;
+  color: #e2e8f0;
+}
+
+.preview-save-btn:disabled,
+.preview-save-btn:disabled:hover {
+  border-color: #2d3748;
+  color: #374151;
+  cursor: not-allowed;
 }
 
 #preview-container {

--- a/public/style.css
+++ b/public/style.css
@@ -1703,6 +1703,22 @@ header p {
   padding: 0.75rem 1.5rem 1rem;
 }
 
+.failed-previews-notice {
+  align-items: center;
+  border: 1px solid #3b2f12;
+  background: #1a1408;
+  border-radius: 6px;
+  display: flex;
+  gap: 0.6rem;
+  justify-content: space-between;
+  margin-bottom: 0.6rem;
+  padding: 0.55rem 0.75rem;
+}
+
+.failed-previews-notice .hint {
+  margin: 0;
+}
+
 .recording-item {
   align-items: center;
   border-bottom: 1px solid #1a2035;

--- a/server.js
+++ b/server.js
@@ -21,7 +21,6 @@ const fs = require('fs');
 const path = require('path');
 const express = require('express');
 const {
-  SCREENCASTS_DIR,
   DEFAULT_SERVER_PORT,
   DEFAULT_BLUEPRINT,
   GENERATED_BLUEPRINT,
@@ -30,7 +29,6 @@ const {
 const app = express();
 
 app.use(express.json());
-app.use('/screencasts', express.static(SCREENCASTS_DIR));
 
 // Route modules — each registers its own handlers on `app`.
 require('./server/routes/translate').register(app);
@@ -39,6 +37,7 @@ require('./server/routes/scripts').register(app);
 require('./server/routes/directions').register(app);
 require('./server/routes/runner').register(app);
 require('./server/routes/recordings').register(app);
+require('./server/routes/previews').register(app);
 require('./server/routes/plugins').register(app);
 require('./server/routes/themes').register(app);
 

--- a/server/config.js
+++ b/server/config.js
@@ -20,7 +20,6 @@ module.exports = {
   OUTPUT_DIR:              path.join(ROOT, 'output'),
   PLAYWRIGHT_OUTPUT_DIR:   path.join(ROOT, 'output', '.playwright'),
   PREVIEW_OUTPUT_DIR:      path.join(ROOT, 'output', '.previews'),
-  SCREENCASTS_DIR:         path.join(ROOT, 'output', '.screencasts'),
   DIRECTIONS_DIR:          path.join(ROOT, 'directions'),
   BUILTIN_DIRECTIONS_DIR:  path.join(__dirname, 'directions'),
 

--- a/server/config.js
+++ b/server/config.js
@@ -11,6 +11,7 @@
 const path = require('path');
 
 const ROOT = path.join(__dirname, '..');
+const DISPOSABLE_OUTPUT_DIR = path.join(ROOT, 'output', '.previews');
 
 module.exports = {
   ROOT,
@@ -19,7 +20,8 @@ module.exports = {
   STEPS_DIR:               path.join(ROOT, 'scripts'),
   OUTPUT_DIR:              path.join(ROOT, 'output'),
   PLAYWRIGHT_OUTPUT_DIR:   path.join(ROOT, 'output', '.playwright'),
-  PREVIEW_OUTPUT_DIR:      path.join(ROOT, 'output', '.previews'),
+  DISPOSABLE_OUTPUT_DIR,
+  PREVIEW_OUTPUT_DIR:      DISPOSABLE_OUTPUT_DIR,
   DIRECTIONS_DIR:          path.join(ROOT, 'directions'),
   BUILTIN_DIRECTIONS_DIR:  path.join(__dirname, 'directions'),
 

--- a/server/routes/previews.js
+++ b/server/routes/previews.js
@@ -1,0 +1,48 @@
+// @ts-check
+
+/**
+ * Failed-preview cleanup.
+ *
+ *   GET    /api/previews   → { count, items: [{ dirname, mtime }] }
+ *   DELETE /api/previews   → empty PREVIEW_OUTPUT_DIR
+ *
+ * Preview runs write a video to `output/.previews/preview-<slug>-<timestamp>/`
+ * so a failing run leaves a debuggable artifact. Successful previews are
+ * deleted by the runner itself; what remains here is the failure backlog.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { PREVIEW_OUTPUT_DIR } = require('../config');
+
+function listPreviewDirs() {
+  if (!fs.existsSync(PREVIEW_OUTPUT_DIR)) return [];
+  return fs.readdirSync(PREVIEW_OUTPUT_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const dir = path.join(PREVIEW_OUTPUT_DIR, entry.name);
+      const stat = fs.statSync(dir);
+      return { dirname: entry.name, mtime: stat.mtimeMs };
+    })
+    .sort((a, b) => b.mtime - a.mtime);
+}
+
+function register(app) {
+  app.get('/api/previews', (req, res) => {
+    const items = listPreviewDirs();
+    res.json({ count: items.length, items });
+  });
+
+  app.delete('/api/previews', (req, res) => {
+    try {
+      if (fs.existsSync(PREVIEW_OUTPUT_DIR)) {
+        fs.rmSync(PREVIEW_OUTPUT_DIR, { recursive: true, force: true });
+      }
+      res.json({ cleared: true });
+    } catch (err) {
+      res.status(500).json({ error: err.message || 'Could not clear previews' });
+    }
+  });
+}
+
+module.exports = { register };

--- a/server/routes/previews.js
+++ b/server/routes/previews.js
@@ -16,8 +16,14 @@ const path = require('path');
 const { PREVIEW_OUTPUT_DIR } = require('../config');
 
 function listPreviewDirs() {
-  if (!fs.existsSync(PREVIEW_OUTPUT_DIR)) return [];
-  return fs.readdirSync(PREVIEW_OUTPUT_DIR, { withFileTypes: true })
+  let entries;
+  try {
+    entries = fs.readdirSync(PREVIEW_OUTPUT_DIR, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === 'ENOENT') return [];
+    throw err;
+  }
+  return entries
     .filter((entry) => entry.isDirectory())
     .map((entry) => {
       const dir = path.join(PREVIEW_OUTPUT_DIR, entry.name);
@@ -35,9 +41,7 @@ function register(app) {
 
   app.delete('/api/previews', (req, res) => {
     try {
-      if (fs.existsSync(PREVIEW_OUTPUT_DIR)) {
-        fs.rmSync(PREVIEW_OUTPUT_DIR, { recursive: true, force: true });
-      }
+      fs.rmSync(PREVIEW_OUTPUT_DIR, { recursive: true, force: true });
       res.json({ cleared: true });
     } catch (err) {
       res.status(500).json({ error: err.message || 'Could not clear previews' });

--- a/server/routes/previews.js
+++ b/server/routes/previews.js
@@ -3,10 +3,8 @@
 /**
  * Latest disposable video endpoints.
  *
- *   GET    /api/previews              → metadata for the current disposable video cache
  *   GET    /api/previews/latest/video → stream the latest disposable WebM
  *   POST   /api/previews/latest/save  → copy latest disposable WebM as a recording
- *   DELETE /api/previews              → empty disposable video cache
  *
  * Play writes a single replaceable video to `output/.previews/latest/`.
  * Saving promotes that WebM into `output/`. MP4 downloads are generated on demand.
@@ -27,24 +25,6 @@ function latestVideoDir() {
 
 function latestVideoPath() {
   return path.join(latestVideoDir(), 'video.webm');
-}
-
-function listPreviewDirs() {
-  let entries;
-  try {
-    entries = fs.readdirSync(PREVIEW_OUTPUT_DIR, { withFileTypes: true });
-  } catch (err) {
-    if (err.code === 'ENOENT') return [];
-    throw err;
-  }
-  return entries
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => {
-      const dir = path.join(PREVIEW_OUTPUT_DIR, entry.name);
-      const stat = fs.statSync(dir);
-      return { dirname: entry.name, mtime: stat.mtimeMs };
-    })
-    .sort((a, b) => b.mtime - a.mtime);
 }
 
 function latestVideoMetadata() {
@@ -104,11 +84,6 @@ function sendVideoFile(req, res, file, filenameBase) {
 }
 
 function register(app) {
-  app.get('/api/previews', (req, res) => {
-    const items = listPreviewDirs();
-    res.json({ count: items.length, items, latest: latestVideoMetadata() });
-  });
-
   app.get('/api/previews/latest/video', (req, res) => {
     const file = latestVideoPath();
     const meta = latestVideoMetadata();
@@ -145,14 +120,6 @@ function register(app) {
     }
   });
 
-  app.delete('/api/previews', (req, res) => {
-    try {
-      fs.rmSync(PREVIEW_OUTPUT_DIR, { recursive: true, force: true });
-      res.json({ cleared: true });
-    } catch (err) {
-      res.status(500).json({ error: err.message || 'Could not clear videos' });
-    }
-  });
 }
 
 module.exports = { register };

--- a/server/routes/previews.js
+++ b/server/routes/previews.js
@@ -1,19 +1,33 @@
 // @ts-check
 
 /**
- * Failed-preview cleanup.
+ * Latest disposable video endpoints.
  *
- *   GET    /api/previews   → { count, items: [{ dirname, mtime }] }
- *   DELETE /api/previews   → empty PREVIEW_OUTPUT_DIR
+ *   GET    /api/previews              → metadata for the current disposable video cache
+ *   GET    /api/previews/latest/video → stream the latest disposable WebM
+ *   POST   /api/previews/latest/save  → copy latest disposable WebM as a recording
+ *   DELETE /api/previews              → empty disposable video cache
  *
- * Preview runs write a video to `output/.previews/preview-<slug>-<timestamp>/`
- * so a failing run leaves a debuggable artifact. Successful previews are
- * deleted by the runner itself; what remains here is the failure backlog.
+ * Play writes a single replaceable video to `output/.previews/latest/`.
+ * Saving promotes that WebM into `output/`. MP4 downloads are generated on demand.
  */
 
 const fs = require('fs');
 const path = require('path');
-const { PREVIEW_OUTPUT_DIR } = require('../config');
+const rangeParser = require('range-parser');
+const { OUTPUT_DIR, PREVIEW_OUTPUT_DIR } = require('../config');
+const { timestamp, timestampedDirname, uniqueDir } = require('../output-paths');
+const { nameToFilename } = require('./scripts');
+
+const LATEST_VIDEO_DIRNAME = 'latest';
+
+function latestVideoDir() {
+  return path.join(PREVIEW_OUTPUT_DIR, LATEST_VIDEO_DIRNAME);
+}
+
+function latestVideoPath() {
+  return path.join(latestVideoDir(), 'video.webm');
+}
 
 function listPreviewDirs() {
   let entries;
@@ -33,10 +47,102 @@ function listPreviewDirs() {
     .sort((a, b) => b.mtime - a.mtime);
 }
 
+function latestVideoMetadata() {
+  const file = latestVideoPath();
+  if (!fs.existsSync(file)) return null;
+
+  const dir = latestVideoDir();
+  const stat = fs.statSync(file);
+  const metaPath = path.join(dir, 'video.json');
+  const legacyMetaPath = path.join(dir, 'preview.json');
+  let meta = {};
+
+  try {
+    meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+  } catch {
+    try {
+      meta = JSON.parse(fs.readFileSync(legacyMetaPath, 'utf8'));
+    } catch {}
+  }
+
+  return {
+    dirname: LATEST_VIDEO_DIRNAME,
+    name: meta.name || 'Play',
+    createdAt: meta.createdAt || stat.mtime.toISOString(),
+    size: stat.size,
+    mtime: stat.mtimeMs,
+  };
+}
+
+function sendVideoFile(req, res, file, filenameBase) {
+  const stat = fs.statSync(file);
+  const range = req.headers.range;
+
+  res.setHeader('Accept-Ranges', 'bytes');
+  res.setHeader('Content-Type', 'video/webm');
+  res.setHeader('Content-Disposition', `inline; filename="${filenameBase}.webm"`);
+
+  if (!range) {
+    res.setHeader('Content-Length', stat.size);
+    fs.createReadStream(file).pipe(res);
+    return;
+  }
+
+  const parsedRange = rangeParser(stat.size, range);
+  if (parsedRange === -1 || parsedRange === -2 || parsedRange.type !== 'bytes' || parsedRange.length !== 1) {
+    res.status(416)
+      .setHeader('Content-Range', `bytes */${stat.size}`)
+      .end();
+    return;
+  }
+
+  const { start, end } = parsedRange[0];
+  res.status(206);
+  res.setHeader('Content-Range', `bytes ${start}-${end}/${stat.size}`);
+  res.setHeader('Content-Length', end - start + 1);
+  fs.createReadStream(file, { start, end }).pipe(res);
+}
+
 function register(app) {
   app.get('/api/previews', (req, res) => {
     const items = listPreviewDirs();
-    res.json({ count: items.length, items });
+    res.json({ count: items.length, items, latest: latestVideoMetadata() });
+  });
+
+  app.get('/api/previews/latest/video', (req, res) => {
+    const file = latestVideoPath();
+    const meta = latestVideoMetadata();
+
+    if (!meta || !fs.existsSync(file)) return res.status(404).end();
+    sendVideoFile(req, res, file, nameToFilename(meta.name).replace(/\.json$/i, ''));
+  });
+
+  app.post('/api/previews/latest/save', async (req, res) => {
+    const source = latestVideoPath();
+    if (!fs.existsSync(source)) return res.status(404).json({ error: 'No video to save' });
+
+    const rawName = String(req.body?.name || latestVideoMetadata()?.name || `recording-${Date.now()}`).trim();
+    const name = rawName || `recording-${Date.now()}`;
+    const slug = nameToFilename(name).replace(/\.json$/i, '');
+    const dirname = path.basename(uniqueDir(path.join(OUTPUT_DIR, timestampedDirname(slug, timestamp()))));
+    const outputDir = path.join(OUTPUT_DIR, dirname);
+    const outputWebm = path.join(outputDir, 'video.webm');
+
+    try {
+      fs.mkdirSync(outputDir, { recursive: true });
+      fs.copyFileSync(source, outputWebm);
+
+      const stat = fs.statSync(outputWebm);
+      res.json({
+        dirname,
+        name,
+        createdAt: stat.mtime.toISOString(),
+        videoUrl: `/api/recordings/${encodeURIComponent(dirname)}/video`,
+      });
+    } catch (err) {
+      try { fs.rmSync(outputDir, { recursive: true, force: true }); } catch {}
+      res.status(500).json({ error: err.message || 'Could not save video' });
+    }
   });
 
   app.delete('/api/previews', (req, res) => {
@@ -44,7 +150,7 @@ function register(app) {
       fs.rmSync(PREVIEW_OUTPUT_DIR, { recursive: true, force: true });
       res.json({ cleared: true });
     } catch (err) {
-      res.status(500).json({ error: err.message || 'Could not clear previews' });
+      res.status(500).json({ error: err.message || 'Could not clear videos' });
     }
   });
 }

--- a/server/routes/recordings.js
+++ b/server/routes/recordings.js
@@ -20,7 +20,7 @@
 const fs = require('fs');
 const path = require('path');
 const rangeParser = require('range-parser');
-const { OUTPUT_DIR, SCREENCASTS_DIR } = require('../config');
+const { OUTPUT_DIR } = require('../config');
 const { findVideoFile, probeVideoSize, spawnMp4Transcode, spawnWebmDownscale } = require('../video');
 const { VIDEO_SIZE_PRESETS } = require('../video-size');
 

--- a/server/routes/recordings.js
+++ b/server/routes/recordings.js
@@ -20,7 +20,7 @@
 const fs = require('fs');
 const path = require('path');
 const rangeParser = require('range-parser');
-const { OUTPUT_DIR, SCREENCASTS_DIR } = require('../config');
+const { OUTPUT_DIR } = require('../config');
 const { findVideoFile } = require('../video');
 
 const TIMESTAMP_PATTERN = /^(.+)-(\d{8}T\d{6}Z)(?:-\d+)?$/;
@@ -160,7 +160,6 @@ function register(app) {
 
     try {
       fs.rmSync(dir, { recursive: true, force: false });
-      fs.rmSync(path.join(SCREENCASTS_DIR, `${dirname}.webm`), { force: true });
       res.json({ deleted: true });
     } catch {
       res.status(500).json({ error: 'Could not delete recording' });

--- a/server/routes/runner.js
+++ b/server/routes/runner.js
@@ -28,7 +28,7 @@
  *   { type: 'stdout',     text: string }          — log line from Playwright/ffmpeg
  *   { type: 'stderr',     text: string }          — error line
  *   { type: 'screencast', data: string }          — base64 JPEG frame for live preview
- *   { type: 'screencastVideo', uri: string }      — public URI for the saved screencast video
+ *   { type: 'previewArtifact', dirname: string }  — failed-preview recording kept for debugging
  *   { type: 'done',       code: number, file?: string }  — terminal event; client closes
  */
 
@@ -39,7 +39,6 @@ const {
   OUTPUT_DIR,
   PLAYWRIGHT_OUTPUT_DIR,
   PREVIEW_OUTPUT_DIR,
-  SCREENCASTS_DIR,
   DEFAULT_BLUEPRINT,
   GENERATED_BLUEPRINT,
 } = require('../config');
@@ -213,8 +212,9 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
 
   let browser = null;
   let context = null;
-  let latestPreviewVideoPath = null;
-  let latestPreviewVideoFilename = null;
+  /** @type {string[]} Dirs created under PREVIEW_OUTPUT_DIR during this run; kept on error, deleted on success. */
+  const previewVideoDirs = [];
+  let runErrored = false;
   let instanceUsed = false;
   const markInstanceUsed = () => {
     if (instanceUsed) return;
@@ -250,16 +250,14 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
       });
       throwIfRunStopped(signal);
 
-      let recordedVideoPath = null;
       const outputSlug = nameToFilename(def.name).replace(/\.json$/i, '');
       const outputStamp = timestamp();
       const outputDirname = timestampedDirname(shouldSaveRecording ? outputSlug : `preview-${outputSlug}`, outputStamp);
       const outputRoot = shouldSaveRecording ? OUTPUT_DIR : PREVIEW_OUTPUT_DIR;
       const videoDir = uniqueDir(path.join(outputRoot, outputDirname));
-      recordedVideoPath = path.join(videoDir, 'video.webm');
+      const recordedVideoPath = path.join(videoDir, 'video.webm');
       fs.mkdirSync(videoDir, { recursive: true });
-      latestPreviewVideoPath = recordedVideoPath;
-      latestPreviewVideoFilename = `${path.basename(videoDir)}.webm`;
+      if (!shouldSaveRecording) previewVideoDirs.push(videoDir);
 
       // Load the site before starting the screencast so the video does not start with a blank screen.
       // Use the blueprint's landingPage if specified; otherwise fall back to the WP admin dashboard.
@@ -286,7 +284,7 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
       const video = page.video();
       await page.close();
       if (run?.page === page) run.page = null;
-      if (video && recordedVideoPath) await video.saveAs(recordedVideoPath);
+      if (video) await video.saveAs(recordedVideoPath);
       if (shouldSaveRecording && recordedVideoPath && code === 0) {
         await processVideo(recordedVideoPath, null, send);
       }
@@ -298,6 +296,7 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
     if (signal?.aborted || err.code === 'RUN_STOPPED') {
       if (run) run.stopRequested = true;
     } else {
+      runErrored = true;
       send({ type: 'stderr', text: `[Playwright] ${err.message}\n` });
       code = 1;
     }
@@ -329,11 +328,14 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
     if (run?.browser === browser) run.browser = null;
   }
 
-  if (latestPreviewVideoPath && latestPreviewVideoFilename && fs.existsSync(latestPreviewVideoPath)) {
-    const publicPath = path.join(SCREENCASTS_DIR, latestPreviewVideoFilename);
-    fs.mkdirSync(SCREENCASTS_DIR, { recursive: true });
-    fs.copyFileSync(latestPreviewVideoPath, publicPath);
-    send({ type: 'screencastVideo', uri: `/screencasts/${latestPreviewVideoFilename}` });
+  for (const dir of previewVideoDirs) {
+    if (runErrored) {
+      if (fs.existsSync(path.join(dir, 'video.webm'))) {
+        send({ type: 'previewArtifact', dirname: path.basename(dir) });
+      }
+    } else {
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+    }
   }
 
   send({ type: 'done', code, ...(wasStopped() ? { stopped: true } : {}), ...doneExtra });

--- a/server/routes/runner.js
+++ b/server/routes/runner.js
@@ -3,7 +3,7 @@
 /**
  * Test-runner endpoints.
  *
- *   POST /api/run        → save + run a single recording, stream logs over SSE
+ *   POST /api/run        → play a single disposable run, stream logs over SSE
  *   POST /api/run/batch  → run multiple saved recordings, stream logs over SSE
  *
  * Both endpoints:
@@ -16,18 +16,19 @@
  *   3. Launch a Chromium browser via the Playwright Node.js API, create a
  *      browser context pointed at the acquired Playground port, and execute
  *      each script's step definitions in order.
- *   4. Stream stdout/stderr and live screencast frames back to the client as
+ *   4. Stream stdout/stderr and live browser frames back to the client as
  *      SSE events.
  *   5. Call pool.release() so the used slot is rebooted in the background,
  *      ready for the run after next.
  *
  * ## SSE event contract
  *
- *   { type: 'stdout',     text: string }          — log line from Playwright/ffmpeg
+ *   { type: 'stdout',     text: string }          — log line from Playwright
  *   { type: 'stderr',     text: string }          — error line
- *   { type: 'screencast', data: string }          — base64 JPEG frame for live preview
- *   { type: 'previewArtifact', dirname: string }  — failed-preview recording kept for debugging
- *   { type: 'done',       code: number, file?: string }  — terminal event; client closes
+ *   { type: 'screencast', data: string }          — base64 JPEG frame from the live browser
+ *   { type: 'videoReady', name: string, videoUrl: string, createdAt: string }
+ *                                            — latest disposable video is ready to replay
+ *   { type: 'done',       code: number, video?: object }  — terminal event; client closes
  */
 
 const fs = require('fs');
@@ -36,7 +37,7 @@ const {
   STEPS_DIR,
   OUTPUT_DIR,
   PLAYWRIGHT_OUTPUT_DIR,
-  PREVIEW_OUTPUT_DIR,
+  DISPOSABLE_OUTPUT_DIR,
   DEFAULT_BLUEPRINT,
   GENERATED_BLUEPRINT,
 } = require('../config');
@@ -171,8 +172,8 @@ function resolveBlueprintPath(blueprint) {
 /**
  * Launch a Chromium browser via the Playwright Node.js API and run each
  * script definition in order, streaming screencast frames and log output
- * back to the caller via `send`. Optionally records a WebM video per script
- * and post-processes it to MP4.
+ * back to the caller via `send`. Each script writes Playwright's captured WebM
+ * to the directory chosen by `outputDirForScript`.
  *
  * @param {Object} opts
  * @param {object[]} opts.scripts                   Step-definition objects to run, in order.
@@ -180,13 +181,13 @@ function resolveBlueprintPath(blueprint) {
  * @param {string}   opts.blueprintPath             Path to the active blueprint file.
  * @param {any}      opts.videoSize                 Target browser viewport/video size.
  * @param {(data: any) => void} opts.send           SSE writer.
- * @param {Object}   [opts.doneExtra]               Extra fields merged into the `done` event.
- * @param {boolean}  [opts.preview]                 Stream live frames and skip saving a recording entry.
+ * @param {(script: object) => string} [opts.outputDirForScript] Chooses the output directory for a script video.
+ * @param {(video: { script: object, videoDir: string, videoPath: string, createdAt: string }) => object | void} [opts.onVideoReady]
  * @param {() => void} [opts.onInstanceUsed]         Called once the Playground instance is actually touched.
  * @param {ReturnType<typeof createRunControl>} [opts.run]
  * @returns {Promise<void>}
  */
-async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send, doneExtra = {}, preview = false, onInstanceUsed = null, run = null }) {
+async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send, outputDirForScript = null, onVideoReady = null, onInstanceUsed = null, run = null }) {
   // IMPORTANT: When running multiple scripts, we are running all of them on the same Playground instance - this may or may not be desired.
   // If we want actions to be executed on the same Playground instance this is fine, but if we want a fresh Playground instance for each script, we need to acquire and release one for each script.
   const { chromium } = require('playwright');
@@ -197,7 +198,6 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
 
   const recordingSize = normalizeVideoSize(videoSize);
   const screencastSize = screencastSizeForVideoSize(recordingSize);
-  const shouldSaveRecording = !preview;
   send({ type: 'stdout', text: `[Playwright] Video size: ${sizeKey(recordingSize)}\n` });
 
   /** @type {import('playwright').BrowserContextOptions} */
@@ -209,8 +209,7 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
 
   let browser = null;
   let context = null;
-  /** @type {string[]} Dirs created under PREVIEW_OUTPUT_DIR during this run. Kept when the run errored, deleted on success. */
-  const previewVideoDirs = [];
+  let latestVideo = null;
   let instanceUsed = false;
   const markInstanceUsed = () => {
     if (instanceUsed) return;
@@ -248,12 +247,11 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
 
       const outputSlug = nameToFilename(def.name).replace(/\.json$/i, '');
       const outputStamp = timestamp();
-      const outputDirname = timestampedDirname(shouldSaveRecording ? outputSlug : `preview-${outputSlug}`, outputStamp);
-      const outputRoot = shouldSaveRecording ? OUTPUT_DIR : PREVIEW_OUTPUT_DIR;
-      const videoDir = uniqueDir(path.join(outputRoot, outputDirname));
+      const videoDir = outputDirForScript
+        ? outputDirForScript(def)
+        : uniqueDir(path.join(OUTPUT_DIR, timestampedDirname(outputSlug, outputStamp)));
       const recordedVideoPath = path.join(videoDir, 'video.webm');
       fs.mkdirSync(videoDir, { recursive: true });
-      if (!shouldSaveRecording) previewVideoDirs.push(videoDir);
 
       // Load the site before starting the screencast so the video does not start with a blank screen.
       // Use the blueprint's landingPage if specified; otherwise fall back to the WP admin dashboard.
@@ -280,7 +278,16 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
       const video = page.video();
       await page.close();
       if (run?.page === page) run.page = null;
-      if (video && recordedVideoPath) await video.saveAs(recordedVideoPath);
+      let savedVideo = false;
+      if (video && recordedVideoPath) {
+        await video.saveAs(recordedVideoPath);
+        savedVideo = true;
+      }
+      if (savedVideo && code === 0) {
+        const createdAt = new Date().toISOString();
+        const readyVideo = onVideoReady?.({ script: def, videoDir, videoPath: recordedVideoPath, createdAt });
+        if (readyVideo) latestVideo = readyVideo;
+      }
     }
 
     await context.close();
@@ -320,16 +327,7 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
     if (run?.browser === browser) run.browser = null;
   }
 
-  const runFailed = code !== 0 && !wasStopped();
-  for (const dir of previewVideoDirs) {
-    if (runFailed) {
-      send({ type: 'previewArtifact', dirname: path.basename(dir) });
-    } else {
-      try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
-    }
-  }
-
-  send({ type: 'done', code, ...(wasStopped() ? { stopped: true } : {}), ...doneExtra });
+  send({ type: 'done', code, ...(latestVideo ? { video: latestVideo } : {}), ...(wasStopped() ? { stopped: true } : {}) });
 }
 
 function register(app) {
@@ -341,14 +339,13 @@ function register(app) {
     }
   });
 
-  // Single-recording run: write the posted steps to a file and run them directly.
+  // Single Play run: execute posted steps and keep only the latest disposable WebM.
   app.post('/api/run', async (req, res) => {
     const {
       name = `recording-${Date.now()}`,
       actions = [],
       blueprint = null,
       videoSize = null,
-      preview = false,
       endPause,
       stepPause,
       typingDelay,
@@ -356,9 +353,8 @@ function register(app) {
     } = req.body;
     if (!actions.length) return res.status(400).json({ error: 'no actions provided' });
 
-    if (!fs.existsSync(STEPS_DIR)) fs.mkdirSync(STEPS_DIR);
-    const filename = nameToFilename(name);
-    const filePath = path.join(STEPS_DIR, filename);
+    try { fs.rmSync(DISPOSABLE_OUTPUT_DIR, { recursive: true, force: true }); } catch {}
+
     const recordingSettings = normalizeRecordingSettings({ endPause, stepPause, typingDelay, videoSize });
     const scriptData = {
       name,
@@ -366,7 +362,6 @@ function register(app) {
       blueprint,
       recordingSettings,
     };
-    fs.writeFileSync(filePath, JSON.stringify(scriptData, null, 2));
 
     sseHeaders(res);
     const send = sseSender(res);
@@ -403,8 +398,17 @@ function register(app) {
         blueprintPath,
         videoSize,
         send,
-        doneExtra: preview ? {} : { file: filePath },
-        preview,
+        outputDirForScript: () => path.join(DISPOSABLE_OUTPUT_DIR, 'latest'),
+        onVideoReady: ({ script, videoDir, createdAt }) => {
+          const video = {
+            name: script.name,
+            createdAt,
+            videoUrl: '/api/previews/latest/video',
+          };
+          fs.writeFileSync(path.join(videoDir, 'video.json'), JSON.stringify({ name: video.name, createdAt }, null, 2));
+          send({ type: 'videoReady', ...video });
+          return video;
+        },
         onInstanceUsed: () => { instanceUsed = true; },
         run,
       });

--- a/server/routes/runner.js
+++ b/server/routes/runner.js
@@ -212,9 +212,8 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
 
   let browser = null;
   let context = null;
-  /** @type {string[]} Dirs created under PREVIEW_OUTPUT_DIR during this run; kept on error, deleted on success. */
+  /** @type {string[]} Dirs created under PREVIEW_OUTPUT_DIR during this run. Kept when the run errored, deleted on success. */
   const previewVideoDirs = [];
-  let runErrored = false;
   let instanceUsed = false;
   const markInstanceUsed = () => {
     if (instanceUsed) return;
@@ -296,7 +295,6 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
     if (signal?.aborted || err.code === 'RUN_STOPPED') {
       if (run) run.stopRequested = true;
     } else {
-      runErrored = true;
       send({ type: 'stderr', text: `[Playwright] ${err.message}\n` });
       code = 1;
     }
@@ -328,11 +326,10 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
     if (run?.browser === browser) run.browser = null;
   }
 
+  const runFailed = code !== 0 && !wasStopped();
   for (const dir of previewVideoDirs) {
-    if (runErrored) {
-      if (fs.existsSync(path.join(dir, 'video.webm'))) {
-        send({ type: 'previewArtifact', dirname: path.basename(dir) });
-      }
+    if (runFailed) {
+      send({ type: 'previewArtifact', dirname: path.basename(dir) });
     } else {
       try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
     }

--- a/server/routes/runner.js
+++ b/server/routes/runner.js
@@ -169,6 +169,22 @@ function resolveBlueprintPath(blueprint) {
   return fs.existsSync(GENERATED_BLUEPRINT) ? GENERATED_BLUEPRINT : DEFAULT_BLUEPRINT;
 }
 
+function clearDirectoryContents(dir) {
+  if (!fs.existsSync(dir)) return;
+
+  for (const entry of fs.readdirSync(dir)) {
+    fs.rmSync(path.join(dir, entry), { recursive: true, force: true });
+  }
+}
+
+function cleanupDisposablePlaywrightFiles() {
+  try {
+    clearDirectoryContents(PLAYWRIGHT_OUTPUT_DIR);
+  } catch (err) {
+    console.warn(`Could not clean disposable output: ${err.message}`);
+  }
+}
+
 /**
  * Launch a Chromium browser via the Playwright Node.js API and run each
  * script definition in order, streaming screencast frames and log output
@@ -422,6 +438,7 @@ function register(app) {
     } finally {
       if (currentRun === run) currentRun = null;
       pool.release(port, { used: instanceUsed });
+      cleanupDisposablePlaywrightFiles();
       if (!res.destroyed && !res.writableEnded) res.end();
     }
   });
@@ -484,6 +501,7 @@ function register(app) {
     } finally {
       if (currentRun === run) currentRun = null;
       pool.release(port, { used: instanceUsed });
+      cleanupDisposablePlaywrightFiles();
       if (!res.destroyed && !res.writableEnded) res.end();
     }
   });

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,7 +14,6 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': 'http://localhost:3000',
-      '/screencasts': 'http://localhost:3000',
     },
   },
 });


### PR DESCRIPTION
This is based on #48

- A new Play button replaces the Record/Preview pair.
- The Play button begins a run and stores only the latest one as a preview.
- Once a preview is ready, a "Save Recording" button is made available.
- The "Save Recording" button saves the latest preview as a recording, which can later be downloaded in any needed format.

Testing instructions:
- Load recordings, use the new "Play" button to start previews, save previews as recordings, etc.
- Make sure all functionality works, previewing the video works, and saving the video works
- Make sure the output directory contains a single preview at most (under a new `latest` directory)
- Make sure no extra files are created beyond the preview and any recordings you save