### PR TITLE
DEVREL-1387: Add more predefined video and browser sizes with optional custom override

### DIFF
--- a/client/Sidebar/RecordingSettingsPanel.jsx
+++ b/client/Sidebar/RecordingSettingsPanel.jsx
@@ -1,15 +1,14 @@
 import clsx from 'clsx';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Dialog } from '../Dialog.jsx';
 import { useAppState } from '../context/AppStateContext.jsx';
 import { DEFAULT_RUN_SETTINGS } from '../state/useRunSettingsState.js';
-import { VIDEO_SIZE_VALUES } from '../utils/actions.js';
+import { BROWSER_SIZE_PRESETS, isValidVideoSizeValue } from '../utils/actions.js';
 
-const VIDEO_LABELS = {
-  '1280x720': '720p',
-  '1920x1080': '1080p',
-  '3840x2160': '4K',
-};
+function splitSizeValue(value) {
+  const match = String(value).match(/^(\d+)x(\d+)$/i);
+  return match ? [match[1], match[2]] : ['', ''];
+}
 
 export function RecordingSettingsPanel() {
   const {
@@ -24,6 +23,13 @@ export function RecordingSettingsPanel() {
     videoSize,
   } = useAppState();
   const [resetDialogOpen, setResetDialogOpen] = useState(false);
+  const [[customWidth, customHeight], setCustomSizeParts] = useState(() => splitSizeValue(videoSize));
+  const activePreset = BROWSER_SIZE_PRESETS.find((preset) => preset.value === videoSize);
+  const customSizeValue = `${customWidth}x${customHeight}`;
+  const customSizeValid = isValidVideoSizeValue(customSizeValue);
+  const normalizedCustomSizeValue = customSizeValid
+    ? `${Number(customWidth)}x${Number(customHeight)}`
+    : customSizeValue;
 
   const isAtDefault = useMemo(
     () => (
@@ -34,6 +40,16 @@ export function RecordingSettingsPanel() {
     ),
     [endPause, stepPause, typingDelay, videoSize],
   );
+
+  useEffect(() => {
+    setCustomSizeParts(splitSizeValue(videoSize));
+  }, [videoSize]);
+
+  function applyCustomSize(event) {
+    event.preventDefault();
+    if (!customSizeValid) return;
+    setVideoSize(normalizedCustomSizeValue);
+  }
 
   return (
     <>
@@ -72,24 +88,61 @@ export function RecordingSettingsPanel() {
 
       <div className="setting-field">
         <div className="setting-field-header">
-          <span className="setting-field-label">Video size</span>
-          <span className="setting-field-value">{videoSize}</span>
+          <span className="setting-field-label">Browser window size</span>
+          <span className="setting-field-value">
+            {activePreset ? `${activePreset.label} ${videoSize}` : `Custom ${videoSize}`}
+          </span>
         </div>
-        <div className="settings-size-toggle" role="radiogroup" aria-label="Video size">
-          {VIDEO_SIZE_VALUES.map((size) => (
+        <div className="settings-size-toggle" role="radiogroup" aria-label="Browser window size">
+          {BROWSER_SIZE_PRESETS.map((preset) => (
             <button
-              key={size}
+              key={preset.value}
               type="button"
-              className={clsx('settings-size-opt', videoSize === size && 'active')}
+              className={clsx('settings-size-opt', videoSize === preset.value && 'active')}
               role="radio"
-              aria-checked={videoSize === size}
-              title={`${VIDEO_LABELS[size]} (${size})`}
-              onClick={() => setVideoSize(size)}
+              aria-checked={videoSize === preset.value}
+              title={`${preset.label} (${preset.value})`}
+              onClick={() => setVideoSize(preset.value)}
             >
-              {VIDEO_LABELS[size]}
+              <span className="settings-size-opt-label">{preset.label}</span>
+              <span className="settings-size-opt-value">{preset.value}</span>
             </button>
           ))}
         </div>
+        <form className="settings-custom-size" onSubmit={applyCustomSize}>
+          <label className="settings-custom-size-field">
+            <span>Width</span>
+            <input
+              type="number"
+              min="320"
+              max="7680"
+              step="1"
+              inputMode="numeric"
+              value={customWidth}
+              onChange={(event) => setCustomSizeParts([event.target.value, customHeight])}
+            />
+          </label>
+          <span className="settings-custom-size-separator">x</span>
+          <label className="settings-custom-size-field">
+            <span>Height</span>
+            <input
+              type="number"
+              min="320"
+              max="7680"
+              step="1"
+              inputMode="numeric"
+              value={customHeight}
+              onChange={(event) => setCustomSizeParts([customWidth, event.target.value])}
+            />
+          </label>
+          <button
+            type="submit"
+            className="settings-custom-size-apply"
+            disabled={!customSizeValid || normalizedCustomSizeValue === videoSize}
+          >
+            Apply
+          </button>
+        </form>
       </div>
 
       <div className="setting-field">
@@ -123,7 +176,7 @@ export function RecordingSettingsPanel() {
     {resetDialogOpen && (
       <Dialog
         title="Reset recording settings?"
-        description="Reset typing speed, between-step pause, video size, and outro length to defaults?"
+        description="Reset typing speed, between-step pause, browser window size, and outro length to defaults?"
         onClose={() => setResetDialogOpen(false)}
       >
         <div className="app-dialog-actions">

--- a/client/utils/actions.js
+++ b/client/utils/actions.js
@@ -19,8 +19,19 @@ export const WP_SCREENS = {
   profile: 'Profile',
 };
 
+export const BROWSER_SIZE_PRESETS = [
+  { label: 'Mobile', value: '390x844' },
+  { label: 'Tablet', value: '768x1024' },
+  { label: '720p', value: '1280x720' },
+  { label: '1080p', value: '1920x1080' },
+  { label: 'QHD', value: '2560x1440' },
+  { label: '4K', value: '3840x2160' },
+];
+
 export const DEFAULT_VIDEO_SIZE_VALUE = '1920x1080';
-export const VIDEO_SIZE_VALUES = ['1280x720', DEFAULT_VIDEO_SIZE_VALUE, '3840x2160'];
+
+const MIN_VIDEO_SIZE = 320;
+const MAX_VIDEO_SIZE = 7680;
 
 let nextDirectionId = 1;
 
@@ -93,19 +104,42 @@ export function flattenDirectionActions(actions = []) {
   ));
 }
 
+function parseSizeValue(value) {
+  if (typeof value === 'string') {
+    const match = value.trim().match(/^(\d{2,5})x(\d{2,5})$/i);
+    if (!match) return null;
+    return { width: Number(match[1]), height: Number(match[2]) };
+  }
+
+  if (value && typeof value === 'object') {
+    return { width: Number(value.width), height: Number(value.height) };
+  }
+
+  return null;
+}
+
+function isValidSize(size) {
+  return Number.isInteger(size?.width)
+    && Number.isInteger(size?.height)
+    && size.width >= MIN_VIDEO_SIZE
+    && size.height >= MIN_VIDEO_SIZE
+    && size.width <= MAX_VIDEO_SIZE
+    && size.height <= MAX_VIDEO_SIZE;
+}
+
+export function isValidVideoSizeValue(value) {
+  return isValidSize(parseSizeValue(value));
+}
+
 export function videoSizeFromValue(value) {
-  const [width, height] = videoSizeValueFromSize(value).split('x').map(Number);
-  return { width, height };
+  const size = parseSizeValue(value);
+  if (isValidSize(size)) return size;
+  return videoSizeFromValue(DEFAULT_VIDEO_SIZE_VALUE);
 }
 
 export function videoSizeValueFromSize(value) {
-  if (typeof value === 'string' && VIDEO_SIZE_VALUES.includes(value)) return value;
-
-  if (value && typeof value === 'object') {
-    const candidate = `${Number(value.width)}x${Number(value.height)}`;
-    if (VIDEO_SIZE_VALUES.includes(candidate)) return candidate;
-  }
-
+  const size = parseSizeValue(value);
+  if (isValidSize(size)) return `${size.width}x${size.height}`;
   return DEFAULT_VIDEO_SIZE_VALUE;
 }
 

--- a/client/utils/actions.js
+++ b/client/utils/actions.js
@@ -1,3 +1,5 @@
+import browserSizePresets from '../../shared/browser-size-presets.json';
+
 export const WP_SCREENS = {
   dashboard: 'Dashboard',
   posts: 'Posts',
@@ -19,14 +21,10 @@ export const WP_SCREENS = {
   profile: 'Profile',
 };
 
-export const BROWSER_SIZE_PRESETS = [
-  { label: 'Mobile', value: '390x844' },
-  { label: 'Tablet', value: '768x1024' },
-  { label: '720p', value: '1280x720' },
-  { label: '1080p', value: '1920x1080' },
-  { label: 'QHD', value: '2560x1440' },
-  { label: '4K', value: '3840x2160' },
-];
+export const BROWSER_SIZE_PRESETS = browserSizePresets.map(({ label, width, height }) => ({
+  label,
+  value: `${width}x${height}`,
+}));
 
 export const DEFAULT_VIDEO_SIZE_VALUE = '1920x1080';
 

--- a/public/style.css
+++ b/public/style.css
@@ -935,27 +935,119 @@ header p {
   border-radius: 6px;
   display: grid;
   gap: 2px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
   padding: 2px;
 }
 
+@media (min-width: 768px) {
+  .settings-size-toggle {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
 .settings-size-opt {
+  align-items: center;
   background: transparent;
   border: none;
   border-radius: 4px;
   color: #94a3b8;
   cursor: pointer;
+  display: flex;
+  flex-direction: column;
   font-size: 0.78rem;
-  font-weight: 500;
+  gap: 0.1rem;
+  min-height: 2.75rem;
   padding: 0.35rem 0.45rem;
   transition: background 0.15s, color 0.15s;
+  width: 100%;
 }
 
 .settings-size-opt:hover { color: #e2e8f0; }
 
 .settings-size-opt.active {
-  background: #6366f1;
-  color: #fff;
+  background: #252f48;
+  color: #e2e8f0;
+}
+
+.settings-size-opt-label,
+.settings-size-opt-value {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-size-opt-label {
+  font-weight: 600;
+}
+
+.settings-size-opt-value {
+  color: #64748b;
+  font-size: 0.7rem;
+}
+
+.settings-size-opt.active .settings-size-opt-value {
+  color: #94a3b8;
+}
+
+.settings-custom-size {
+  align-items: end;
+  display: grid;
+  gap: 0.45rem;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr) auto;
+}
+
+.settings-custom-size-field {
+  color: #64748b;
+  display: flex;
+  flex-direction: column;
+  font-size: 0.7rem;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.settings-custom-size-field input {
+  background: #111827;
+  border: 1px solid #2d3748;
+  border-radius: 5px;
+  color: #e2e8f0;
+  font-size: 0.8rem;
+  min-width: 0;
+  padding: 0.35rem 0.45rem;
+  width: 100%;
+}
+
+.settings-custom-size-field input:focus {
+  border-color: #6366f1;
+  outline: none;
+}
+
+.settings-custom-size-separator {
+  color: #64748b;
+  font-size: 0.8rem;
+  line-height: 2rem;
+}
+
+.settings-custom-size-apply {
+  background: #1a2035;
+  border: 1px solid #2d3748;
+  border-radius: 5px;
+  color: #cbd5e1;
+  cursor: pointer;
+  font-size: 0.78rem;
+  min-height: 2rem;
+  padding: 0.35rem 0.55rem;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.settings-custom-size-apply:hover:not(:disabled) {
+  background: #252f48;
+  border-color: #475569;
+  color: #e2e8f0;
+}
+
+.settings-custom-size-apply:disabled {
+  color: #475569;
+  cursor: not-allowed;
 }
 
 /* ── Steps command bar ───────────────────────────────────── */
@@ -2120,13 +2212,14 @@ header p {
 }
 
 #preview-container {
-  flex: 1;
-  display: flex;
   align-items: center;
-  justify-content: center;
   background: #0a0f1a;
   border: 1px solid #1e2433;
   border-radius: 6px;
+  display: flex;
+  flex: 1;
+  justify-content: center;
+  min-width: 0;
   min-height: 200px;
   overflow: hidden;
 }
@@ -2139,18 +2232,15 @@ header p {
   padding: 2rem;
 }
 
-#preview-img {
-  width: 100%;
-  height: auto;
-  display: block;
-}
-
+#preview-img,
 #preview-video {
-  width: 100%;
-  height: 100%;
-  display: block;
   background: transparent;
+  display: block;
+  height: 100%;
+  max-height: 100%;
+  max-width: 100%;
   object-fit: contain;
+  width: 100%;
 }
 
 #preview-img[hidden] { display: none; }

--- a/server/routes/recordings.js
+++ b/server/routes/recordings.js
@@ -26,14 +26,22 @@ const { VIDEO_SIZE_PRESETS } = require('../video-size');
 
 /**
  * Resolutions a recording can be downloaded at: the captured source size,
- * plus any preset whose width is strictly smaller. Sorted largest-first.
+ * plus any smaller preset with the same aspect ratio. Sorted largest-first.
  *
  * @param {{ width: number, height: number }} sourceSize
  * @returns {{ width: number, height: number }[]}
  */
+function sameAspectRatio(size, sourceSize) {
+  return size.width * sourceSize.height === size.height * sourceSize.width;
+}
+
 function allowedSizesFor(sourceSize) {
   const smaller = VIDEO_SIZE_PRESETS
-    .filter((p) => p.width < sourceSize.width && p.height < sourceSize.height)
+    .filter((p) => (
+      p.width < sourceSize.width
+      && p.height < sourceSize.height
+      && sameAspectRatio(p, sourceSize)
+    ))
     .map((p) => ({ width: p.width, height: p.height }));
   return [{ width: sourceSize.width, height: sourceSize.height }, ...smaller]
     .sort((a, b) => b.width - a.width);
@@ -63,7 +71,13 @@ function resolveDownloadSize(query, sourceSize) {
   }
 
   const isAllowedPreset = VIDEO_SIZE_PRESETS.some(
-    (p) => p.width === width && p.height === height && p.width < sourceSize.width,
+    (p) => (
+      p.width === width
+      && p.height === height
+      && p.width < sourceSize.width
+      && p.height < sourceSize.height
+      && sameAspectRatio(p, sourceSize)
+    ),
   );
   if (!isAllowedPreset) return { kind: 'error', status: 400 };
 

--- a/server/routes/recordings.js
+++ b/server/routes/recordings.js
@@ -33,7 +33,7 @@ const { VIDEO_SIZE_PRESETS } = require('../video-size');
  */
 function allowedSizesFor(sourceSize) {
   const smaller = VIDEO_SIZE_PRESETS
-    .filter((p) => p.width < sourceSize.width)
+    .filter((p) => p.width < sourceSize.width && p.height < sourceSize.height)
     .map((p) => ({ width: p.width, height: p.height }));
   return [{ width: sourceSize.width, height: sourceSize.height }, ...smaller]
     .sort((a, b) => b.width - a.width);

--- a/server/routes/recordings.js
+++ b/server/routes/recordings.js
@@ -24,9 +24,13 @@ const { OUTPUT_DIR } = require('../config');
 const { findVideoFile, probeVideoSize, spawnMp4Transcode, spawnWebmDownscale } = require('../video');
 const { VIDEO_SIZE_PRESETS } = require('../video-size');
 
+const MAX_DOWNLOAD_SIZE = VIDEO_SIZE_PRESETS.find((size) => size.width === 3840 && size.height === 2160)
+  ?? VIDEO_SIZE_PRESETS[VIDEO_SIZE_PRESETS.length - 1];
+
 /**
  * Resolutions a recording can be downloaded at: the captured source size,
- * plus any smaller preset with the same aspect ratio. Sorted largest-first.
+ * exact same-aspect presets, and larger same-aspect sizes fit into presets up
+ * to 4K. Sorted largest-first.
  *
  * @param {{ width: number, height: number }} sourceSize
  * @returns {{ width: number, height: number }[]}
@@ -35,15 +39,47 @@ function sameAspectRatio(size, sourceSize) {
   return size.width * sourceSize.height === size.height * sourceSize.width;
 }
 
+function sizeKey(size) {
+  return `${size.width}x${size.height}`;
+}
+
+function fitsWithin(size, maxSize) {
+  return size.width <= maxSize.width && size.height <= maxSize.height;
+}
+
+function fitSourceRatioWithin(sourceSize, bounds) {
+  const scale = Math.min(bounds.width / sourceSize.width, bounds.height / sourceSize.height);
+  if (!Number.isFinite(scale) || scale <= 0) return null;
+  return {
+    width: Math.round(sourceSize.width * scale),
+    height: Math.round(sourceSize.height * scale),
+  };
+}
+
 function allowedSizesFor(sourceSize) {
-  const smaller = VIDEO_SIZE_PRESETS
+  const exactPresetSizes = VIDEO_SIZE_PRESETS
     .filter((p) => (
-      p.width < sourceSize.width
-      && p.height < sourceSize.height
+      fitsWithin(p, MAX_DOWNLOAD_SIZE)
       && sameAspectRatio(p, sourceSize)
     ))
     .map((p) => ({ width: p.width, height: p.height }));
-  return [{ width: sourceSize.width, height: sourceSize.height }, ...smaller]
+
+  const upscaleSizes = VIDEO_SIZE_PRESETS
+    .filter((preset) => fitsWithin(preset, MAX_DOWNLOAD_SIZE))
+    .map((preset) => fitSourceRatioWithin(sourceSize, preset))
+    .filter((size) => (
+      size
+      && size.width > sourceSize.width
+      && size.height > sourceSize.height
+      && fitsWithin(size, MAX_DOWNLOAD_SIZE)
+    ));
+
+  const sizesByKey = new Map([
+    [sizeKey(sourceSize), { width: sourceSize.width, height: sourceSize.height }],
+    ...exactPresetSizes.map((size) => [sizeKey(size), size]),
+    ...upscaleSizes.map((size) => [sizeKey(size), size]),
+  ]);
+  return [...sizesByKey.values()]
     .sort((a, b) => b.width - a.width);
 }
 
@@ -70,16 +106,10 @@ function resolveDownloadSize(query, sourceSize) {
     return { kind: 'source' };
   }
 
-  const isAllowedPreset = VIDEO_SIZE_PRESETS.some(
-    (p) => (
-      p.width === width
-      && p.height === height
-      && p.width < sourceSize.width
-      && p.height < sourceSize.height
-      && sameAspectRatio(p, sourceSize)
-    ),
+  const isAllowedSize = allowedSizesFor(sourceSize).some(
+    (size) => size.width === width && size.height === height,
   );
-  if (!isAllowedPreset) return { kind: 'error', status: 400 };
+  if (!isAllowedSize) return { kind: 'error', status: 400 };
 
   return { kind: 'scale', size: { width, height } };
 }

--- a/server/routes/runner.js
+++ b/server/routes/runner.js
@@ -220,6 +220,7 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
   const contextOpts = {
     baseURL: `http://127.0.0.1:${port}`,
     viewport: recordingSize,
+    screen: recordingSize,
   };
   contextOpts.recordVideo = { dir: PLAYWRIGHT_OUTPUT_DIR, size: recordingSize };
 
@@ -238,6 +239,7 @@ async function runPlaywrightApi({ scripts, port, blueprintPath, videoSize, send,
     browser = await chromium.launch({
       headless: true,
       slowMo: 500,
+      args: [`--window-size=${recordingSize.width},${recordingSize.height}`],
     });
     if (run) run.browser = browser;
     throwIfRunStopped(signal);

--- a/server/video-size.js
+++ b/server/video-size.js
@@ -3,11 +3,14 @@
 const VIDEO_SIZE_PRESETS = Object.freeze([
   Object.freeze({ width: 1280, height: 720 }),
   Object.freeze({ width: 1920, height: 1080 }),
+  Object.freeze({ width: 2560, height: 1440 }),
   Object.freeze({ width: 3840, height: 2160 }),
 ]);
 
 const DEFAULT_VIDEO_SIZE = VIDEO_SIZE_PRESETS[1];
 const MAX_SCREENCAST_WIDTH = 1280;
+const MIN_VIDEO_SIZE = 320;
+const MAX_VIDEO_SIZE = 7680;
 
 function cloneSize(size) {
   return { width: size.width, height: size.height };
@@ -31,16 +34,25 @@ function parseVideoSize(value) {
   return null;
 }
 
+function isValidVideoSize(size) {
+  return Number.isInteger(size?.width)
+    && Number.isInteger(size?.height)
+    && size.width >= MIN_VIDEO_SIZE
+    && size.height >= MIN_VIDEO_SIZE
+    && size.width <= MAX_VIDEO_SIZE
+    && size.height <= MAX_VIDEO_SIZE;
+}
+
 function normalizeVideoSize(value, fallback = DEFAULT_VIDEO_SIZE) {
   const parsed = parseVideoSize(value);
-  if (!parsed || !Number.isFinite(parsed.width) || !Number.isFinite(parsed.height)) {
+  if (!isValidVideoSize(parsed)) {
     return fallback ? cloneSize(fallback) : null;
   }
 
   const preset = VIDEO_SIZE_PRESETS.find((size) => (
     size.width === parsed.width && size.height === parsed.height
   ));
-  return preset ? cloneSize(preset) : (fallback ? cloneSize(fallback) : null);
+  return preset ? cloneSize(preset) : cloneSize(parsed);
 }
 
 function videoSizeFromEnv() {

--- a/server/video-size.js
+++ b/server/video-size.js
@@ -1,13 +1,14 @@
 // @ts-check
 
-const VIDEO_SIZE_PRESETS = Object.freeze([
-  Object.freeze({ width: 1280, height: 720 }),
-  Object.freeze({ width: 1920, height: 1080 }),
-  Object.freeze({ width: 2560, height: 1440 }),
-  Object.freeze({ width: 3840, height: 2160 }),
-]);
+const BROWSER_SIZE_PRESETS = require('../shared/browser-size-presets.json');
 
-const DEFAULT_VIDEO_SIZE = VIDEO_SIZE_PRESETS[1];
+const VIDEO_SIZE_PRESETS = Object.freeze(BROWSER_SIZE_PRESETS.map(({ width, height }) => (
+  Object.freeze({ width, height })
+)));
+
+const DEFAULT_VIDEO_SIZE = VIDEO_SIZE_PRESETS.find((size) => (
+  size.width === 1920 && size.height === 1080
+)) ?? VIDEO_SIZE_PRESETS[0];
 const MAX_SCREENCAST_WIDTH = 1280;
 const MIN_VIDEO_SIZE = 320;
 const MAX_VIDEO_SIZE = 7680;

--- a/shared/browser-size-presets.json
+++ b/shared/browser-size-presets.json
@@ -1,8 +1,5 @@
 [
   { "label": "Mobile", "width": 390, "height": 844 },
   { "label": "Tablet", "width": 768, "height": 1024 },
-  { "label": "720p", "width": 1280, "height": 720 },
-  { "label": "1080p", "width": 1920, "height": 1080 },
-  { "label": "QHD", "width": 2560, "height": 1440 },
-  { "label": "4K", "width": 3840, "height": 2160 }
+  { "label": "Desktop", "width": 1920, "height": 1080 }
 ]

--- a/shared/browser-size-presets.json
+++ b/shared/browser-size-presets.json
@@ -1,0 +1,8 @@
+[
+  { "label": "Mobile", "width": 390, "height": 844 },
+  { "label": "Tablet", "width": 768, "height": 1024 },
+  { "label": "720p", "width": 1280, "height": 720 },
+  { "label": "1080p", "width": 1920, "height": 1080 },
+  { "label": "QHD", "width": 2560, "height": 1440 },
+  { "label": "4K", "width": 3840, "height": 2160 }
+]


### PR DESCRIPTION
Introduce more predefined resolution options and add a way to specify a custom resolution for videos.
This makes it possible to record videos in "mobile" view as well.

<img width="705" height="448" alt="Screenshot 2026-05-19 at 15 59 07" src="https://github.com/user-attachments/assets/fb6c2492-b37b-4c7e-9c6a-f7a06ba428da" />
