### PR TITLE
DEVREL-1436: Move highlight ring to the popover top layer

### DIFF
--- a/recordings/overlay.js
+++ b/recordings/overlay.js
@@ -1,0 +1,36 @@
+// @ts-check
+
+/**
+ * Shared top-layer overlay host for recording visualizations (highlight ring,
+ * future key-press HUD, etc.).
+ *
+ * Uses the Popover API (`popover="manual"` + `.showPopover()`) so the host
+ * renders in the browser's top layer — above any WordPress popover, modal, or
+ * dropdown regardless of its z-index or stacking context. Children use
+ * `position: fixed` with viewport coords as usual; top-layer affects painting,
+ * not the containing block.
+ */
+
+/**
+ * Idempotently inject the top-layer host on the page. Re-runs safely after
+ * navigation (the host is wiped with the document).
+ *
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<void>}
+ */
+async function ensureOverlayHost(page) {
+  await page.evaluate(() => {
+    if (document.getElementById('psdd-overlay-host')) return;
+    const host = document.createElement('div');
+    host.id = 'psdd-overlay-host';
+    host.setAttribute('popover', 'manual');
+    host.style.cssText = `
+      position:fixed;inset:0;margin:0;padding:0;border:0;
+      width:100vw;height:100vh;
+      background:transparent;pointer-events:none;overflow:visible;`;
+    document.body.appendChild(host);
+    host.showPopover();
+  });
+}
+
+module.exports = { ensureOverlayHost };

--- a/recordings/run-steps.js
+++ b/recordings/run-steps.js
@@ -7,6 +7,8 @@
  * `runPlaywrightApi` in `server/routes/runner.js` (Playwright library API).
  */
 
+const { ensureOverlayHost } = require('./overlay');
+
 const HIGHLIGHT_HOLD = 700;
 const DEFAULT_END_PAUSE = 2000;
 const DEFAULT_STEP_PAUSE = 0;
@@ -26,9 +28,9 @@ function stepTypingDelay(step, settings, fallback = DEFAULT_TYPING_DELAY) {
  * Scroll `locator` into view, inject a pulsing blue ring around it for
  * `HIGHLIGHT_HOLD` ms, click it, then remove the ring.
  *
- * The ring is injected into the top-level page (not into any iframe) so it
- * renders above the editor-canvas iframe overlay. The animation is CSS
- * keyframe-based and inlined to avoid any stylesheet dependency.
+ * The ring is appended to a top-layer popover host (see `overlay.js`) so it
+ * paints above any WordPress popover/modal/dropdown regardless of z-index or
+ * stacking context.
  *
  * @param {import('@playwright/test').Page} page
  * @param {import('@playwright/test').Locator} locator
@@ -38,6 +40,7 @@ async function highlightAndClick(page, locator) {
   await locator.scrollIntoViewIfNeeded();
   const box = await locator.boundingBox();
   if (box) {
+    await ensureOverlayHost(page);
     await page.evaluate(({ cx, cy, d }) => {
       if (!document.getElementById('psdd-highlight-style')) {
         const style = document.createElement('style');
@@ -52,12 +55,13 @@ async function highlightAndClick(page, locator) {
       const ring = document.createElement('div');
       ring.id = 'psdd-click-ring';
       ring.style.cssText = `
-        position:fixed;z-index:999998;pointer-events:none;
+        position:fixed;pointer-events:none;
         left:${cx - d / 2}px;top:${cy - d / 2}px;width:${d}px;height:${d}px;
         border:3px solid #3b82f6;border-radius:50%;
         box-shadow:0 0 12px rgba(59,130,246,.5);
         animation:psdd-pulse .9s ease-in-out;`;
-      document.body.appendChild(ring);
+      const host = document.getElementById('psdd-overlay-host');
+      (host ?? document.body).appendChild(ring);
     }, {
       cx: box.x + box.width / 2,
       cy: box.y + box.height / 2,


### PR DESCRIPTION
## Summary
- The pulsing highlight ring was injected on `document.body` with `z-index: 999998`, which left it behind WordPress popovers/modals that establish their own stacking contexts (block inserter panel, inspector panels, block toolbar dropdowns, etc.).
- Introduces a shared `recordings/overlay.js` helper that injects a `<div popover="manual">` host and calls `.showPopover()`, putting it in the browser's top layer above any popover regardless of z-index or stacking context.
- `highlightAndClick` now appends the ring into that host and drops the inline z-index.
- The host is pointer-events transparent and idempotent (safe to call before every overlay; re-injects after navigations). Future recording overlays (e.g. the key-press HUD in DEVREL-1424) will reuse it.

Linear: https://linear.app/a8c/issue/DEVREL-1436/the-circle-indicator-is-sometime-behind-items

Plan: `plans/ring-top-layer.md`

## Test plan
- [ ] Run a recording that uses `highlightClick` on an element while the block inserter side panel is open — ring is visible above the panel.
- [ ] Same check against an open inspector panel (e.g. Categories / Featured image).
- [ ] Same check against an open block-toolbar dropdown (e.g. Align text).
- [ ] Run an existing recording end-to-end (e.g. `basic-insert`) — no regression in normal ring behavior.
- [ ] Ring still appears correctly after a `wpNavigate` step (host re-injects on the fresh document).